### PR TITLE
feat: 사진 업로드 시, webp 변환 후 업로드 구현

### DIFF
--- a/src/apis/services/photo.ts
+++ b/src/apis/services/photo.ts
@@ -13,11 +13,12 @@ export const photoService = {
     token: string
   ) => {
     const formData = new FormData();
-    const webpBlobs = await Promise.all(
+    const webpFiles = await Promise.all<File>(
       photoFileArray.map(async file => photoFileToWebp(file))
     );
-    webpBlobs.forEach(blob => {
-      return formData.append('files', blob);
+
+    webpFiles.forEach(file => {
+      formData.append('files', file);
     });
 
     const encodedMetadata = encodeURIComponent(JSON.stringify(metadataArray));

--- a/src/apis/services/photo.ts
+++ b/src/apis/services/photo.ts
@@ -5,14 +5,20 @@ import type {
   PhotoMetadata,
   UploadedFullPhoto,
 } from '../../types/photo.type';
+import { photoFileToWebp } from '@utils/photo';
 export const photoService = {
-  uploadPhoto: (
+  uploadPhoto: async (
     photoFileArray: File[],
     metadataArray: PhotoMetadata[],
     token: string
   ) => {
     const formData = new FormData();
-    photoFileArray.forEach(file => formData.append('files', file));
+    const webpBlobs = await Promise.all(
+      photoFileArray.map(async file => photoFileToWebp(file))
+    );
+    webpBlobs.forEach(blob => {
+      return formData.append('files', blob);
+    });
 
     const encodedMetadata = encodeURIComponent(JSON.stringify(metadataArray));
     return http.post<{ uploadedPhotos: UploadedFullPhoto[] }>(
@@ -55,7 +61,11 @@ export const photoService = {
     return http.post(`/api/photos/${photoId}/comments`, { content }, token);
   },
   updatePhotoComment: (photoId: number, content: string, token: string) => {
-    return http.put<{ content: string }>(`/api/photos/${photoId}/comments`, { content }, token);
+    return http.put<{ content: string }>(
+      `/api/photos/${photoId}/comments`,
+      { content },
+      token
+    );
   },
   deletePhotoComment: (photoId: number, token: string) => {
     return http.delete(`/api/photos/${photoId}/comments`, token);

--- a/src/components/TravelItem/TravelItem.tsx
+++ b/src/components/TravelItem/TravelItem.tsx
@@ -21,6 +21,7 @@ export default function TravelItem({ travel }: Props) {
             currentTarget.onerror = null;
             currentTarget.src = FallbackImage;
           }}
+          fetchPriority="high"
         />
       </Link>
       <Link to={`/travel/${travel.travelId}`} className={classes.infoContainer}>

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -2,25 +2,37 @@ export async function photoFileToWebp(photoFile: File) {
   return new Promise<Blob>((resolve, reject) => {
     const imageURL = URL.createObjectURL(photoFile);
     const image = new Image();
-    image.src = imageURL;
+    image.onerror = () => {
+      reject(
+        new Error('이미지 변환에 사용될 이미지를 불러오기 실패하였습니다.')
+      );
+      URL.revokeObjectURL(imageURL);
+    };
     image.onload = () => {
       const canvas = document.createElement('canvas');
       canvas.width = image.width;
       canvas.height = image.height;
       const context = canvas.getContext('2d');
+      if (!context) {
+        reject(
+          new Error('이미지 변환에 필요한 Canvas Context를 찾을 수 없습니다.')
+        );
+        return;
+      }
       context?.drawImage(image, 0, 0);
       canvas.toBlob(
         blob => {
           if (blob) {
             resolve(blob);
           } else {
-            throw Error('이미지 변환 실패');
+            reject(new Error('이미지 변환 실패'));
           }
         },
         'image/webp',
         0.7
       );
-      image.onerror = reject;
+      URL.revokeObjectURL(imageURL);
     };
+    image.src = imageURL;
   });
 }

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -1,0 +1,26 @@
+export async function photoFileToWebp(photoFile: File) {
+  return new Promise<Blob>((resolve, reject) => {
+    const imageURL = URL.createObjectURL(photoFile);
+    const image = new Image();
+    image.src = imageURL;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.width;
+      canvas.height = image.height;
+      const context = canvas.getContext('2d');
+      context?.drawImage(image, 0, 0);
+      canvas.toBlob(
+        blob => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            throw Error('이미지 변환 실패');
+          }
+        },
+        'image/webp',
+        0.7
+      );
+      image.onerror = reject;
+    };
+  });
+}

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -1,5 +1,5 @@
 export async function photoFileToWebp(photoFile: File) {
-  return new Promise<Blob>((resolve, reject) => {
+  return new Promise<File>((resolve, reject) => {
     const imageURL = URL.createObjectURL(photoFile);
     const image = new Image();
     image.onerror = () => {
@@ -23,7 +23,9 @@ export async function photoFileToWebp(photoFile: File) {
       canvas.toBlob(
         blob => {
           if (blob) {
-            resolve(blob);
+            resolve(
+              new File([blob], photoFile.name.replace(/(\.[^/.]+)?$/, '.webp'))
+            );
           } else {
             reject(new Error('이미지 변환 실패'));
           }


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#33 의 일환으로 사진 업로드 시 사진 파일을 webp로 변환(원본의 퀄리티 0.7배)하여 사진 용량과 다운로드 소요시간을 낮췄습니다.

### 스크린샷 또는 구동 연상(선택)
원본 이미지 기준 용량 2.5mb -> 565kb(약 77% 감소), 다운로드 소요시간 433ms -> 144ms (약 66% 감소) 
(다운로드 소요시간은 요청환경 등에 따라 다를 수 있습니다)

원본
<img width="996" height="17" alt="스크린샷 2026-03-13 오후 5 45 20" src="https://github.com/user-attachments/assets/3702419f-e04a-4fc3-a563-90dcd9efb7df" />
webp 적용
<img width="999" height="18" alt="스크린샷 2026-03-13 오후 5 46 01" src="https://github.com/user-attachments/assets/24fb83d1-c6ea-4846-9967-a422a7e9d118" />



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
