### PR TITLE
feat: 공통 모달 컴포넌트 구현

### DIFF
--- a/src/components/Buttons/Button/Button.module.css
+++ b/src/components/Buttons/Button/Button.module.css
@@ -17,3 +17,6 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+.button:active {
+  filter: brightness(85%);
+}

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -24,11 +24,6 @@
     margin: 0 auto;
   }
 }
-.datetimePicker {
-  background-color: transparent;
-  border-style: none;
-  font-size: 14px;
-}
 
 .modal {
   width: 70%;

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,0 +1,68 @@
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 5;
+  animation: 0.5s cubic-bezier(0.075, 0.82, 0.165, 1) 0s alternate fade-in;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (min-width: 440px) {
+  .modalOverlay {
+    width: 440px;
+    margin: 0 auto;
+  }
+}
+.datetimePicker {
+  background-color: transparent;
+  border-style: none;
+  font-size: 14px;
+}
+
+.modal {
+  width: 70%;
+  min-height: 15%;
+  border-radius: 5px;
+  background: #ffffff;
+  padding: 24px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  gap: 16px;
+}
+
+.modalButtonGroup {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.modalButton {
+  min-width: 59px;
+  height: 32px;
+  border-radius: 5px;
+  border: none;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 100%;
+  letter-spacing: 0;
+  color: #fff;
+  cursor: pointer;
+}
+
+.modalTitle {
+  font-size: 20px;
+  margin: 0;
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,65 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import Button from '@components/Buttons/Button/Button';
+import classes from './Modal.module.css';
+interface Props {
+  isOpen: boolean;
+  onCancel: () => void;
+  children?: ReactNode;
+}
+
+export function Modal({ children }: { children: ReactNode }) {
+  return children;
+}
+
+function Title({ children }: { children: ReactNode }) {
+  return (
+    <h2 id="modal-title" className={classes.modalTitle}>
+      {children}
+    </h2>
+  );
+}
+
+function ButtonGroup({ children }: { children: ReactNode }) {
+  return <div className={classes.modalButtonGroup}>{children}</div>;
+}
+
+function ModalButton({
+  children,
+  className,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <Button {...props} className={`${classes.modalButton} ${className ?? ''}`}>
+      {children}
+    </Button>
+  );
+}
+
+function Root({ isOpen, onCancel, children }: Props) {
+  const handleOuterClick = () => {
+    onCancel();
+  };
+  return isOpen ? (
+    <div
+      className={`${classes.modalOverlay} ${isOpen ? '' : classes.hidden}`}
+      role="presentation"
+      onClick={handleOuterClick}
+    >
+      <div
+        className={classes.modal}
+        role="dialog"
+        aria-labelledby="modal-title"
+        onClick={event => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  ) : (
+    ''
+  );
+}
+Modal.Root = Root;
+Modal.ButtonGroup = ButtonGroup;
+Modal.Button = ModalButton;
+Modal.Title = Title;
+export default Modal;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -41,7 +41,7 @@ function Root({ isOpen, onCancel, children }: Props) {
   };
   return isOpen ? (
     <div
-      className={`${classes.modalOverlay} ${isOpen ? '' : classes.hidden}`}
+      className={classes.modalOverlay}
       role="presentation"
       onClick={handleOuterClick}
     >

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -54,9 +54,7 @@ function Root({ isOpen, onCancel, children }: Props) {
         {children}
       </div>
     </div>
-  ) : (
-    ''
-  );
+  ) : null;
 }
 Modal.Root = Root;
 Modal.ButtonGroup = ButtonGroup;


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#40 에서 논의되었던 alert 제목이 변경 불가한 문제로 #48 공통 모달 컴포넌트를 제작 후 alert을 변경할(#49) 예정입니다. 

그에 일환으로 공통으로 사용할 수 있는 모달 컴포넌트를 구현하였습니다.
기본적으로 모달 컴포넌트는 페이드 인 효과가 추가 되었고, `Title`, `ButtonGroup`, `ModalButton`을 사용자의 취향대로 합성하여 사용할 수 있게 구현하였습니다.

사용 예

```tsx
<Modal.Root isOpen={isOpen} onCancel={() => setIsOpen(false)}>
  <Modal.Title>권한 없음</Modal.Title>
  로그인 페이지로 이동합니다.
  <Modal.ButtonGroup>
    <Modal.Button
      style={{ backgroundColor: 'gray' }}
      onClick={() => {
        setIsOpen(false);
      }}
    >
      취소
    </Modal.Button>
    <Modal.Button>확인</Modal.Button>
  </Modal.ButtonGroup>
</Modal.Root>
```

### 스크린샷 또는 구동 연상(선택)


https://github.com/user-attachments/assets/0c51d4ca-bdcb-4a1e-a7fb-f00ccd1292f0



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
