### PR TITLE
feat: alert 공통 모달로 교체 

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -20,6 +20,7 @@ import LogInPage from './pages/LogInPage/LogInPage';
 import SelectThumbnailPage from './pages/SelectThumbnailPage/SelectThumbnailPage';
 import SelectThumbnailPhotoPage from './pages/SelectThumbnailPhotoPage/SelectThumbnailPhotoPage';
 import MapPage from './pages/MapPage/MapPage';
+import ErrorRoute from './pages/ErrorPage/ErrorRoute';
 
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
@@ -34,6 +35,10 @@ const router = createBrowserRouter([
       {
         path: '/login',
         Component: LogInPage,
+      },
+      {
+        path: '/error/:status',
+        Component: ErrorRoute,
       },
       // ✅ 보호된 경로 그룹
       {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -57,6 +57,17 @@
   cursor: pointer;
 }
 
+.blue {
+  background-color: #0d9eff;
+}
+
+.red {
+  background-color: #f62424;
+}
+
+.gray {
+  background-color: #757575;
+}
 .modalTitle {
   font-size: 20px;
   margin: 0;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,8 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import Button from '@components/Buttons/Button/Button';
 import classes from './Modal.module.css';
+
+type ModalButtonVariant = 'blue' | 'red' | 'gray';
 interface Props {
   isOpen: boolean;
   onCancel: () => void;
@@ -25,11 +27,15 @@ function ButtonGroup({ children }: { children: ReactNode }) {
 
 function ModalButton({
   children,
+  variant = 'blue',
   className,
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ModalButtonVariant }) {
   return (
-    <Button {...props} className={`${classes.modalButton} ${className ?? ''}`}>
+    <Button
+      {...props}
+      className={`${classes.modalButton} ${classes[variant]} ${className ?? ''}`}
+    >
       {children}
     </Button>
   );

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,19 +1,32 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
+import useModal from '@hooks/useModal';
 
 /**
  * 로그인이 필요한 페이지를 보호하는 컴포넌트입니다.
  * 토큰이 없으면 로그인 페이지로 리다이렉트합니다.
  */
 const ProtectedRoute = () => {
-    // 현재 프로젝트에서 혼용되는 키 확인 (로그인 로직에 맞춤)
-    const token = localStorage.getItem('accessToken');
+  // 현재 프로젝트에서 혼용되는 키 확인 (로그인 로직에 맞춤)
+  const token = localStorage.getItem('accessToken');
+  const navigate = useNavigate();
+  const { modalElement } = useModal(
+    !token
+      ? {
+          title: '권한없음',
+          message: '로그인이 필요한 서비스 입니다.',
+          cancelText: '취소',
+          confirmText: '확인',
+          onCancel: () => navigate('/error/401', { replace: true }),
+          onConfirm: () => navigate('/login', { replace: true }),
+        }
+      : undefined
+  );
 
-    if (!token) {
-        alert('로그인이 필요한 서비스입니다.');
-        return <Navigate to="/login" replace />;
-    }
+  if (!token) {
+    return modalElement;
+  }
 
-    return <Outlet />;
+  return <Outlet />;
 };
 
 export default ProtectedRoute;

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import Modal from '@components/Modal/Modal';
+
+type OpenModalOptions = {
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+};
+
+type InitialModalOptions = OpenModalOptions & {
+  isOpen?: boolean;
+};
+
+type ModalState = {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText: string;
+  cancelText: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+};
+
+const initialState: ModalState = {
+  isOpen: false,
+  title: '확인',
+  message: '',
+  confirmText: '확인',
+  cancelText: '취소',
+};
+
+export default function useModal(initialOptions?: InitialModalOptions) {
+  const [state, setState] = useState<ModalState>(() => {
+    if (!initialOptions) return initialState;
+
+    return {
+      isOpen: initialOptions.isOpen ?? true,
+      title: initialOptions.title ?? '확인',
+      message: initialOptions.message,
+      confirmText: initialOptions.confirmText ?? '확인',
+      cancelText: initialOptions.cancelText ?? '취소',
+      onConfirm: initialOptions.onConfirm,
+      onCancel: initialOptions.onCancel,
+    };
+  });
+
+  const closeModal = () => {
+    setState(prev => ({ ...prev, isOpen: false }));
+  };
+
+  const openModal = (options: OpenModalOptions) => {
+    setState({
+      isOpen: true,
+      title: options.title ?? '확인',
+      message: options.message,
+      confirmText: options.confirmText ?? '확인',
+      cancelText: options.cancelText ?? '취소',
+      onConfirm: options.onConfirm,
+      onCancel: options.onCancel,
+    });
+  };
+
+  const handleConfirm = () => {
+    state.onConfirm?.();
+    closeModal();
+  };
+
+  const handleCancel = () => {
+    state.onCancel?.();
+    closeModal();
+  };
+
+  const modalElement = (
+    <Modal.Root isOpen={state.isOpen} onCancel={handleCancel}>
+      <Modal.Title>{state.title}</Modal.Title>
+      <p>{state.message}</p>
+      <Modal.ButtonGroup>
+        <Modal.Button variant="gray" onClick={handleCancel}>
+          {state.cancelText}
+        </Modal.Button>
+        <Modal.Button variant="blue" onClick={handleConfirm}>
+          {state.confirmText}
+        </Modal.Button>
+      </Modal.ButtonGroup>
+    </Modal.Root>
+  );
+
+  return { openModal, closeModal, modalElement };
+}

--- a/src/pages/EditTravelPage/EditTravelPage.tsx
+++ b/src/pages/EditTravelPage/EditTravelPage.tsx
@@ -4,6 +4,7 @@ import type { NewTravelInfo, FullTravel } from 'src/types/travel.type';
 import { travelService } from 'src/apis/services/travel';
 
 import { useApi } from '@hooks/api';
+import useModal from '@hooks/useModal';
 const convertTravelToTravelInfo = (travel: FullTravel) => {
   return {
     title: travel.title,
@@ -19,9 +20,9 @@ const convertTravelToTravelInfo = (travel: FullTravel) => {
           GPSCoordinates:
             latitude && longitude
               ? {
-                longitude: longitude,
-                latitude: latitude,
-              }
+                  longitude: longitude,
+                  latitude: latitude,
+                }
               : null,
           url: url as string,
           link: 'photo',
@@ -36,7 +37,7 @@ export default function EditTravelPage() {
   const token = localStorage.getItem('accessToken');
   const [travel, setTravel] = useState<NewTravelInfo>();
   const { data, error, request, loading } = useApi(travelService.getTravel);
-
+  const { openModal, modalElement } = useModal();
   useEffect(() => {
     if (token && !data) {
       request(state.travelId, token);
@@ -45,12 +46,20 @@ export default function EditTravelPage() {
 
   useEffect(() => {
     if (error) {
-      alert(error);
+      openModal({
+        title: '오류',
+        message: error,
+      });
       return;
     }
     if (data && !travel) {
       setTravel(convertTravelToTravelInfo(data));
     }
-  }, [data, error, travel, convertTravelToTravelInfo]);
-  return <Outlet context={{ travel, setTravel, loading, error }} />;
+  }, [data, error, travel, openModal]);
+  return (
+    <>
+      <Outlet context={{ travel, setTravel, loading, error }} />
+      {modalElement}
+    </>
+  );
 }

--- a/src/pages/ErrorPage/ErrorRoute.tsx
+++ b/src/pages/ErrorPage/ErrorRoute.tsx
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom';
+import ErrorPage from './ErrorPage';
+
+export default function ErrorRoute() {
+  const { status } = useParams<{ status: string }>();
+  const parsedStatus = Number(status);
+  const safeStatus = Number.isNaN(parsedStatus) ? null : parsedStatus;
+
+  const messageByStatus: Record<number, string> = {
+    401: '로그인이 필요한 서비스 입니다.',
+    403: '접근 권한이 없습니다.',
+    404: '요청하신 페이지를 찾을 수 없습니다.',
+    500: '서버 내부 오류가 발생했습니다.',
+  };
+
+  const message =
+    safeStatus && messageByStatus[safeStatus]
+      ? messageByStatus[safeStatus]
+      : undefined;
+
+  return <ErrorPage status={safeStatus} message={message} />;
+}

--- a/src/pages/LogInPage/LogInPage.tsx
+++ b/src/pages/LogInPage/LogInPage.tsx
@@ -6,16 +6,18 @@ import BackButton from '../../components/Buttons/BackButton/BlackBackButton/Blac
 import Button from '../../components/Buttons/Button/Button';
 import { authService } from '../../apis/services/auth';
 import type { LoginInput } from '../../types/auth.type'; // 타입 경로 확인 필요
+import useModal from '@hooks/useModal';
 
 export default function LogInPage() {
   const navigate = useNavigate();
+  const { openModal, modalElement } = useModal();
 
   // 1. React Hook Form 설정
   const {
     register,
     handleSubmit,
     setError,
-    formState: { errors }
+    formState: { errors },
   } = useForm<LoginInput>();
 
   // 2. 로그인 제출 핸들러
@@ -32,7 +34,6 @@ export default function LogInPage() {
         localStorage.setItem('accessToken', token.access_token);
 
         // 메인 페이지로 이동
-        alert('로그인에 성공했습니다.');
         navigate('/');
       }
     } catch (error: any) {
@@ -44,19 +45,24 @@ export default function LogInPage() {
       if (status === 400) {
         setError('password', { message: '이메일과 비밀번호를 입력해주세요.' });
       } else if (status === 403) {
-        setError('password', { message: '이메일 또는 비밀번호가 일치하지 않습니다.' });
+        setError('password', {
+          message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+        });
       } else if (status === 404) {
         setError('email', { message: '가입되지 않은 이메일입니다.' });
       } else {
         const errorMessage = error.message || '로그인에 실패했습니다.';
-        alert(errorMessage);
+        openModal({
+          title: '오류',
+          message: errorMessage,
+        });
       }
     }
   };
 
   return (
     <div className={classes.container}>
-      <Link to='/..'>
+      <Link to="/..">
         <div className={classes.backButton}>
           <BackButton />
         </div>
@@ -85,15 +91,22 @@ export default function LogInPage() {
             className={classes.passwordInput}
           />
           {errors.password && (
-            <span className={classes.errorMessage}>{errors.password.message}</span>
+            <span className={classes.errorMessage}>
+              {errors.password.message}
+            </span>
           )}
         </div>
 
-        <Link to="/signup" className={classes.signUp}>회원가입</Link>
+        <Link to="/signup" className={classes.signUp}>
+          회원가입
+        </Link>
 
         {/* 버튼 타입 submit으로 지정 */}
-        <Button type="submit" className={classes.logInButton}>로그인</Button>
+        <Button type="submit" className={classes.logInButton}>
+          로그인
+        </Button>
       </form>
+      {modalElement}
     </div>
   );
 }

--- a/src/pages/MyTravelPage/MyTravelPage.tsx
+++ b/src/pages/MyTravelPage/MyTravelPage.tsx
@@ -26,8 +26,12 @@ export default function MyTravelPage() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401',{viewTranstion : true}),
-        onConfirm: () => navigate('/login',{viewTranstion : true, state:{forward:true}}),
+        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onConfirm: () =>
+          navigate('/login', {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
       return;
     }

--- a/src/pages/MyTravelPage/MyTravelPage.tsx
+++ b/src/pages/MyTravelPage/MyTravelPage.tsx
@@ -2,6 +2,7 @@ import classes from './MyTravelPage.module.css';
 import NavigationBar from '@components/NavigationBar/NavigationBar';
 import TravelList from '@components/TravelList/TravelList';
 import { useApi } from '@hooks/api';
+import useModal from '@hooks/useModal';
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
@@ -9,6 +10,7 @@ import { travelService } from 'src/apis/services/travel';
 export default function MyTravelPage() {
   const navigate = useNavigate();
   const token = localStorage.getItem('accessToken');
+  const { openModal, modalElement } = useModal();
   const { data, error, request, loading, status } = useApi(
     travelService.getTravels
   );
@@ -21,11 +23,15 @@ export default function MyTravelPage() {
 
   useEffect(() => {
     if (!token || status === 401) {
-      alert('로그인이 필요한 서비스입니다.');
-      navigate('/login');
+      openModal({
+        title: '권한없음',
+        message: '로그인이 필요한 서비스입니다.',
+        onCancel: () => navigate('/error/401'),
+        onConfirm: () => navigate('/login'),
+      });
       return;
     }
-  }, [token, status, navigate]);
+  }, [token, status, navigate, openModal]);
 
   return (
     <>
@@ -46,6 +52,7 @@ export default function MyTravelPage() {
         <TravelList travels={data} />
       )}
       <NavigationBar nowTab="my-travel" />
+      {modalElement}
     </>
   );
 }

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -7,14 +7,20 @@ import { useTravel } from '@hooks/travel';
 import { useApi } from '@hooks/api';
 import { travelService } from 'src/apis/services/travel';
 import { useEffect } from 'react';
+import useModal from '@hooks/useModal';
 export default function SelectThumbnailPage() {
   const token = localStorage.getItem('accessToken');
   const { travel } = useTravel();
+  const { openModal, modalElement } = useModal();
   const { loading, data, error, request } = useApi(travelService.createTravel);
   const handleClickButton = () => {
     if (!token) {
-      alert('로그인이 필요한 서비스입니다.');
-      navigate('/login');
+      openModal({
+        title: '권한없음',
+        message: '로그인이 필요한 서비스입니다.',
+        onCancel: () => navigate('/error/401'),
+        onConfirm: () => navigate('/login'),
+      });
       return;
     }
     request(travel, token);
@@ -24,12 +30,19 @@ export default function SelectThumbnailPage() {
       return;
     }
     if (error) {
-      alert(error);
+      openModal({
+        title: '에러',
+        message: error,
+      });
       return;
     }
     if (data) {
-      alert(`성공적으로 여행을 추가했습니다.${'\n'}여행페이지로 이동합니다.`);
-      navigate(`/travel/${data}`);
+      openModal({
+        title: '여행 생성 성공',
+        message: `성공적으로 여행을 생성했습니다.${'\n'}여행페이지로 이동합니다.`,
+        onCancel: () => navigate(`/travel/${data}`),
+        onConfirm: () => navigate(`/travel/${data}`),
+      });
     }
   }, [error, loading, data]);
   const thumbnailCheckedPhotos = travel.photos.map(photo => {
@@ -74,6 +87,7 @@ export default function SelectThumbnailPage() {
           ? '여행을 생성하고 있어요. 완료되면 자동으로 여행 페이지로 이동해요.'
           : ''}
       </p>
+      {modalElement}
     </div>
   );
 }

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -18,8 +18,12 @@ export default function SelectThumbnailPage() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401',{viewTranstion : true}),
-        onConfirm: () => navigate('/login',{viewTranstion : true, state:{forward:true}}),
+        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onConfirm: () =>
+          navigate('/login', {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
       return;
     }
@@ -40,14 +44,16 @@ export default function SelectThumbnailPage() {
       openModal({
         title: '여행 생성 성공',
         message: `성공적으로 여행을 생성했습니다.${'\n'}여행페이지로 이동합니다.`,
-        onCancel: () => navigate(`/travel/${data}`, {
-          viewTransition: true,
-          state: { forward: true },
-        }),
-        onConfirm: () => navigate(`/travel/${data}`, {
-          viewTransition: true,
-          state: { forward: true },
-        })
+        onCancel: () =>
+          navigate(`/travel/${data}`, {
+            viewTransition: true,
+            state: { forward: true },
+          }),
+        onConfirm: () =>
+          navigate(`/travel/${data}`, {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
     }
   }, [error, loading, data]);

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -5,20 +5,26 @@ import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import Button from '@components/Buttons/Button/Button';
 import { useEditTravel } from '@hooks/travel';
 import { useApi } from '@hooks/api';
+import useModal from '@hooks/useModal';
 import { travelService } from 'src/apis/services/travel';
 import { useEffect } from 'react';
 export default function SelectThumbnailPageForEdit() {
   const token = localStorage.getItem('accessToken');
   const { state } = useLocation();
   const { travel } = useEditTravel();
+  const { openModal, modalElement } = useModal();
   const navigate = useNavigate();
   const { error, data, loading, request } = useApi(
     travelService.updateTravelInfo
   );
   const handleClickButton = () => {
     if (!token) {
-      alert('로그인이 필요한 서비스입니다.');
-      navigate('/login');
+      openModal({
+        title: '권한없음',
+        message: '로그인이 필요한 서비스입니다.',
+        onCancel: () => navigate('/error/401'),
+        onConfirm: () => navigate('/login'),
+      });
       return;
     }
     request(state.travelId, travel, token);
@@ -28,14 +34,21 @@ export default function SelectThumbnailPageForEdit() {
       return;
     }
     if (error) {
-      alert(error);
+      openModal({
+        title: '에러',
+        message: error,
+      });
       return;
     }
     if (data) {
-      alert(`성공적으로 여행을 수정했습니다.${'\n'}여행페이지로 이동합니다.`);
-      navigate(`/travel/${state.travelId}`);
+      openModal({
+        title: '여행 수정 성공',
+        message: `성공적으로 여행을 수정했습니다.${'\n'}여행페이지로 이동합니다.`,
+        onCancel: () => navigate(`/travel/${state.travelId}`),
+        onConfirm: () => navigate(`/travel/${state.travelId}`),
+      });
     }
-  }, [loading, error, data, navigate, state.travelId]);
+  }, [loading, error, data, navigate, openModal, state.travelId]);
   const thumbnailCheckedPhotos = travel.photos.map(photo => {
     return {
       ...photo,
@@ -77,6 +90,7 @@ export default function SelectThumbnailPageForEdit() {
           ? '여행을 수정하고 있어요. 완료되면 자동으로 여행 페이지로 이동해요.'
           : ''}
       </p>
+      {modalElement}
     </div>
   );
 }

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -22,8 +22,12 @@ export default function SelectThumbnailPageForEdit() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401',{viewTranstion : true}),
-        onConfirm: () => navigate('/login',{viewTranstion : true, state:{forward:true}}),
+        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onConfirm: () =>
+          navigate('/login', {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
       return;
     }
@@ -44,14 +48,16 @@ export default function SelectThumbnailPageForEdit() {
       openModal({
         title: '여행 수정 성공',
         message: `성공적으로 여행을 수정했습니다.${'\n'}여행페이지로 이동합니다.`,
-        onCancel: () => navigate(`/travel/${data}`, {
-          viewTransition: true,
-          state: { forward: true },
-        }),
-        onConfirm: () => navigate(`/travel/${data}`, {
-          viewTransition: true,
-          state: { forward: true },
-        })
+        onCancel: () =>
+          navigate(`/travel/${data}`, {
+            viewTransition: true,
+            state: { forward: true },
+          }),
+        onConfirm: () =>
+          navigate(`/travel/${data}`, {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
     }
   }, [loading, error, data, navigate, openModal, state.travelId]);

--- a/src/pages/SharedTravelPhotoComment/SharedTravelPhotoComment.tsx
+++ b/src/pages/SharedTravelPhotoComment/SharedTravelPhotoComment.tsx
@@ -8,7 +8,10 @@ import { travelService } from 'src/apis/services/travel';
 import { useApi } from 'src/hooks/api';
 
 export default function SharedTravelPhotoComment() {
-  const {shareToken, photoId } = useParams<{shareToken: string; photoId: string }>();
+  const { shareToken, photoId } = useParams<{
+    shareToken: string;
+    photoId: string;
+  }>();
   const [isFullPhoto, setIsFullPhoto] = useState(false);
   const navigate = useNavigate();
 
@@ -41,16 +44,17 @@ export default function SharedTravelPhotoComment() {
     return dateString.split('T')[0];
   };
 
-  const latestComment = photo.comments && photo.comments.length > 0
-    ? [...photo.comments].sort((a, b) => b.commentId - a.commentId)[0]
-    : null;
+  const latestComment =
+    photo.comments && photo.comments.length > 0
+      ? [...photo.comments].sort((a, b) => b.commentId - a.commentId)[0]
+      : null;
 
   const datedPhotoData: DatedPhotoData = {
     id: photo.photoId ?? Number(photoId),
     url: photo.url || '',
     date: photo.createdDate || new Date().toISOString(),
     file: new File([], photo.originalName ?? 'photo'),
-    isThumbnail: false
+    isThumbnail: false,
   };
 
   if (isFullPhoto) {
@@ -88,14 +92,21 @@ export default function SharedTravelPhotoComment() {
         <div className={classes.photoInformation}>
           <a>{formatDate(photo.takenAt)}</a>
           <br />
-          {/* @ts-expect-error: region is not in FullPhoto type but present in API response */}
-          {photo.region ? photo.region : (photo.latitude && photo.longitude ? `${photo.latitude}, ${photo.longitude}` : '')}
+          {photo.region
+            ? photo.region
+            : photo.latitude && photo.longitude
+              ? `${photo.latitude}, ${photo.longitude}`
+              : ''}
         </div>
-        
+
         <div className={classes.textAreaContainer}>
-           <div className={`${classes.commentBox} ${!latestComment ? classes.noComment : ''}`}>
-             {latestComment ? latestComment.content : '작성된 코멘트가 없습니다.'}
-           </div>
+          <div
+            className={`${classes.commentBox} ${!latestComment ? classes.noComment : ''}`}
+          >
+            {latestComment
+              ? latestComment.content
+              : '작성된 코멘트가 없습니다.'}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/SharedTravelPhotoComment/SharedTravelPhotoComment.tsx
+++ b/src/pages/SharedTravelPhotoComment/SharedTravelPhotoComment.tsx
@@ -16,7 +16,7 @@ export default function SharedTravelPhotoComment() {
   }>();
   const [isFullPhoto, setIsFullPhoto] = useState(false);
   const navigate = useNavigate();
-
+  const { isMobile, launchAppScheme } = useAppScheme(shareToken);
   const {
     data: travel,
     loading: travelLoading,

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -8,6 +8,7 @@ import LogoImg from '../../assets/images/Logo.svg';
 import BackButton from '../../components/Buttons/BackButton/BlackBackButton/BlackBackButton';
 import Button from '../../components/Buttons/Button/Button';
 import { SignUpSchema } from './SignUpSchema';
+import useModal from '@hooks/useModal';
 
 // API 서비스 import
 import { authService } from '../../apis/services/auth';
@@ -16,15 +17,16 @@ type SignUpForm = z.infer<typeof SignUpSchema>;
 
 export default function SignUpPage() {
   const navigate = useNavigate(); // 페이지 이동을 위한 훅
+  const { openModal, modalElement } = useModal();
 
   const {
     register,
     handleSubmit,
     setError,
-    formState: { errors }
+    formState: { errors },
   } = useForm<SignUpForm>({
     resolver: zodResolver(SignUpSchema),
-    mode: 'onChange' // 입력할 때마다 실시간으로 유효성 검사 (선택 사항)
+    mode: 'onChange', // 입력할 때마다 실시간으로 유효성 검사 (선택 사항)
   });
 
   const onSubmit = async (data: SignUpForm) => {
@@ -35,13 +37,17 @@ export default function SignUpPage() {
         email: data.email,
         password: data.password,
         password_check: data.passwordCheck,
-        privacy_policy_agreed: data.agree
+        privacy_policy_agreed: data.agree,
       } as any);
 
       // 성공 시 처리
-      alert('회원가입이 성공적으로 완료되었습니다!\n로그인 페이지로 이동합니다.');
-      navigate('/login');
-
+      openModal({
+        title: '회원가입 성공',
+        message:
+          '회원가입이 성공적으로 완료되었습니다!\n로그인 페이지로 이동합니다.',
+        onCancel: () => navigate('/login'),
+        onConfirm: () => navigate('/login'),
+      });
     } catch (error: any) {
       console.error('회원가입 에러:', error);
 
@@ -50,16 +56,20 @@ export default function SignUpPage() {
       if (status === 400) {
         setError('email', { message: '중복된 이메일입니다.' });
       } else {
-        const errorMsg = error.responseBody || error.message || "알 수 없는 에러";
-        const statusCode = status || "";
-        alert(`회원가입 실패 (${statusCode}):\n${errorMsg}`);
+        const errorMsg =
+          error.responseBody || error.message || '알 수 없는 에러';
+        const statusCode = status || '';
+        openModal({
+          title: '회원가입 실패',
+          message: `회원가입 실패 (${statusCode}):\n${errorMsg}`,
+        });
       }
     }
   };
 
   return (
     <div className={classes.container}>
-      <Link to='/login'>
+      <Link to="/login">
         <div className={classes.backButton}>
           <BackButton />
         </div>
@@ -69,18 +79,12 @@ export default function SignUpPage() {
 
       {/* 폼 제출 핸들러 연결 */}
       <form onSubmit={handleSubmit(onSubmit)} className={classes.signUpForm}>
-
         {/* 이메일 */}
         <div className={classes.idForm}>
           <h3>이메일</h3>
-          <input
-            {...register('email')}
-            className={classes.idInput}
-          />
+          <input {...register('email')} className={classes.idInput} />
           {errors.email && (
-            <span className={classes.errorMessage}>
-              {errors.email.message}
-            </span>
+            <span className={classes.errorMessage}>{errors.email.message}</span>
           )}
         </div>
 
@@ -123,20 +127,23 @@ export default function SignUpPage() {
               className={classes.checkboxInput}
             />
             <span>
-              <a href="https://lilac-crystal-fca.notion.site/2fdc68016f76806b90b0ec82a710b7c9">개인정보약관</a>에 동의하시겠습니까?
+              <a href="https://lilac-crystal-fca.notion.site/2fdc68016f76806b90b0ec82a710b7c9">
+                개인정보약관
+              </a>
+              에 동의하시겠습니까?
             </span>
           </label>
 
           {errors.agree && (
-            <span className={classes.errorMessage}>
-              {errors.agree.message}
-            </span>
+            <span className={classes.errorMessage}>{errors.agree.message}</span>
           )}
         </div>
 
-        <Button type="submit" className={classes.signUpButton}>회원가입</Button>
+        <Button type="submit" className={classes.signUpButton}>
+          회원가입
+        </Button>
       </form>
-
+      {modalElement}
     </div>
   );
 }

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -45,12 +45,16 @@ export default function SignUpPage() {
         title: '회원가입 성공',
         message:
           '회원가입이 성공적으로 완료되었습니다!\n로그인 페이지로 이동합니다.',
-        onCancel: () => navigate('/login' {
-          viewTransition: true,
-          state: {forward: true}}),
-        onConfirm: () => navigate('/login'{
-          viewTransition: true,
-          state: {forward: true}}),
+        onCancel: () =>
+          navigate('/login', {
+            viewTransition: true,
+            state: { forward: true },
+          }),
+        onConfirm: () =>
+          navigate('/login', {
+            viewTransition: true,
+            state: { forward: true },
+          }),
       });
     } catch (error: any) {
       console.error('회원가입 에러:', error);

--- a/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
+++ b/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import classes from './TravelPhotoComment.module.css'
-import BackButton from 'src/components/Buttons/BackButton/GrayBackButton/GrayBackButton'
-import DeleteButton from 'src/components/Buttons/DeleteButton/DeleteButton'
+import classes from './TravelPhotoComment.module.css';
+import BackButton from 'src/components/Buttons/BackButton/GrayBackButton/GrayBackButton';
+import DeleteButton from 'src/components/Buttons/DeleteButton/DeleteButton';
 import DeleteConfirmModal from '../../components/Modal/DeleteConfirmModal.tsx';
 import Button from '@components/Buttons/Button/Button';
 import FullPhotoLayout from '@components/FullPhotoLayout/FullPhotoLayout';
@@ -11,16 +11,21 @@ import { photoService } from 'src/apis/services/photo';
 import { travelService } from 'src/apis/services/travel';
 import { useApi } from 'src/hooks/api';
 import ErrorPage from '../ErrorPage/ErrorPage.tsx';
+import useModal from '@hooks/useModal';
 
 export default function TravelPhotoComment() {
-  const { travelId, photoId } = useParams<{ travelId: string; photoId: string }>();
+  const { travelId, photoId } = useParams<{
+    travelId: string;
+    photoId: string;
+  }>();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isFullPhoto, setIsFullPhoto] = useState(false);
   const [commentText, setCommentText] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [currentCommentId, setCurrentCommentId] = useState<number | null>(null);
 
-  const navigate = useNavigate()
+  const navigate = useNavigate();
+  const { openModal, modalElement } = useModal();
 
   const {
     data: travel,
@@ -33,18 +38,16 @@ export default function TravelPhotoComment() {
   const {
     status: writeStatus,
     request: writeComment,
-    reset: resetWrite
+    reset: resetWrite,
   } = useApi(photoService.writePhotoComment);
 
   const {
     status: updateStatus,
     request: updateComment,
-    reset: resetUpdate
+    reset: resetUpdate,
   } = useApi(photoService.updatePhotoComment);
 
-  const {
-    request: deletePhoto
-  } = useApi(photoService.deletePhoto);
+  const { request: deletePhoto } = useApi(photoService.deletePhoto);
 
   useEffect(() => {
     if (writeStatus === 201) {
@@ -52,13 +55,19 @@ export default function TravelPhotoComment() {
       if (travelId && token) {
         fetchTravel(Number(travelId), token);
       }
-      alert('코멘트가 성공적으로 저장되었습니다.');
+      openModal({
+        title: '코멘트 저장 성공',
+        message: '코멘트가 성공적으로 저장되었습니다.',
+      });
       resetWrite();
     } else if (writeStatus !== null) {
-      alert('코멘트 저장 중 오류가 발생했습니다.');
+      openModal({
+        title: '코멘트 저장 실패',
+        message: '코멘트 저장 중 오류가 발생했습니다.',
+      });
       resetWrite();
     }
-  }, [writeStatus, travelId, fetchTravel, resetWrite]);
+  }, [writeStatus, travelId, fetchTravel, openModal, resetWrite]);
 
   useEffect(() => {
     if (updateStatus === 200) {
@@ -66,13 +75,19 @@ export default function TravelPhotoComment() {
       if (travelId && token) {
         fetchTravel(Number(travelId), token);
       }
-      alert('코멘트가 성공적으로 저장되었습니다.');
+      openModal({
+        title: '코멘트 수정 성공',
+        message: '코멘트가 성공적으로 저장되었습니다.',
+      });
       resetUpdate();
     } else if (updateStatus !== null) {
-      alert('코멘트 수정 중 오류가 발생했습니다.');
+      openModal({
+        title: '코멘트 수정 실패',
+        message: '코멘트 수정 중 오류가 발생했습니다.',
+      });
       resetUpdate();
     }
-  }, [updateStatus, travelId, fetchTravel, resetUpdate]);
+  }, [updateStatus, travelId, fetchTravel, openModal, resetUpdate]);
 
   useEffect(() => {
     const token = localStorage.getItem('accessToken');
@@ -91,7 +106,9 @@ export default function TravelPhotoComment() {
   useEffect(() => {
     if (photo?.comments && photo.comments.length > 0) {
       // Find comment with highest commentId
-      const latestComment = [...photo.comments].sort((a, b) => b.commentId - a.commentId)[0];
+      const latestComment = [...photo.comments].sort(
+        (a, b) => b.commentId - a.commentId
+      )[0];
       setCommentText(latestComment.content);
       setIsEditing(true);
       setCurrentCommentId(latestComment.commentId);
@@ -135,7 +152,10 @@ export default function TravelPhotoComment() {
       }
     } catch (error) {
       console.error('코멘트 저장 실패:', error);
-      alert('코멘트 저장 중 오류가 발생했습니다.');
+      openModal({
+        title: '코멘트 저장 실패',
+        message: '코멘트 저장 중 오류가 발생했습니다.',
+      });
     }
   };
 
@@ -151,7 +171,9 @@ export default function TravelPhotoComment() {
   };
 
   useEffect(() => {
-    const textarea = document.querySelector(`.${classes.textAreaWrapper}`) as HTMLTextAreaElement;
+    const textarea = document.querySelector(
+      `.${classes.textAreaWrapper}`
+    ) as HTMLTextAreaElement;
     if (textarea) {
       textarea.style.height = 'auto';
       textarea.style.height = `${textarea.scrollHeight}px`;
@@ -159,24 +181,29 @@ export default function TravelPhotoComment() {
   }, [commentText]);
 
   if (travelLoading) return <div>Loading...</div>;
-  if (travelError) return <ErrorPage status={travelStatus} message={travelError} />;
-  if (!travel || !photo) return <ErrorPage status={404} message="No data found." />;
+  if (travelError)
+    return <ErrorPage status={travelStatus} message={travelError} />;
+  if (!travel || !photo)
+    return <ErrorPage status={404} message="No data found." />;
 
   const datedPhotoData: DatedPhotoData = {
     id: photo.photoId ?? Number(photoId),
     url: photo.url || '',
     date: photo.createdDate || new Date().toISOString(),
     file: new File([], photo.originalName ?? 'photo'),
-    isThumbnail: false
+    isThumbnail: false,
   };
 
   if (isFullPhoto) {
     return (
-      <FullPhotoLayout photo={datedPhotoData}>
-        <div className={classes.backButtonWrapper} style={{ zIndex: 10 }}>
-          <BackButton onClick={() => setIsFullPhoto(false)} />
-        </div>
-      </FullPhotoLayout>
+      <>
+        <FullPhotoLayout photo={datedPhotoData}>
+          <div className={classes.backButtonWrapper} style={{ zIndex: 10 }}>
+            <BackButton onClick={() => setIsFullPhoto(false)} />
+          </div>
+        </FullPhotoLayout>
+        {modalElement}
+      </>
     );
   }
 
@@ -209,11 +236,15 @@ export default function TravelPhotoComment() {
           <a>{formatDate(photo.takenAt)}</a>
           <br />
           {/* @ts-expect-error: region is not in FullPhoto type but present in API response */}
-          {photo.region ? photo.region : (photo.latitude && photo.longitude ? `${photo.latitude}, ${photo.longitude}` : '')}
+          {photo.region
+            ? photo.region
+            : photo.latitude && photo.longitude
+              ? `${photo.latitude}, ${photo.longitude}`
+              : ''}
         </div>
-        
+
         <div className={classes.textAreaContainer}>
-           <textarea
+          <textarea
             className={classes.textAreaWrapper}
             value={commentText}
             onChange={handleInputChange}
@@ -222,7 +253,9 @@ export default function TravelPhotoComment() {
         </div>
 
         <div className={classes.finishButton}>
-          <Button onClick={handleFinishClick}>{isEditing ? '수정' : '작성'}</Button>
+          <Button onClick={handleFinishClick}>
+            {isEditing ? '수정' : '작성'}
+          </Button>
         </div>
       </div>
 
@@ -233,6 +266,7 @@ export default function TravelPhotoComment() {
           onConfirm={handleConfirmDelete}
         />
       )}
+      {modalElement}
     </div>
   );
 }

--- a/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
+++ b/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
@@ -235,7 +235,6 @@ export default function TravelPhotoComment() {
         <div className={classes.photoInformation}>
           <a>{formatDate(photo.takenAt)}</a>
           <br />
-          {/* @ts-expect-error: region is not in FullPhoto type but present in API response */}
           {photo.region
             ? photo.region
             : photo.latitude && photo.longitude

--- a/src/types/photo.type.ts
+++ b/src/types/photo.type.ts
@@ -28,6 +28,7 @@ export interface Photo {
   createdDate?: string;
   modifiedDate?: string;
   comments: Comment[];
+  region: string;
 }
 
 export interface PhotoGeoData {


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#40 (#49)에서 논의 했던 것 처럼, alert 제목은 수정이 불가해서 공통 모달 컴포넌트를 제작하였고, 이번에 alert을 modal로 교체했습니다. 
그 과정에서 modal을 더 쉽게 열 수 있게 useModal 커스텀 훅을 구현하여 처리하였습니다.
그 밖에도 불필요한 로그인 성공 시 alert을 제거하였고, 모달 버튼에 색깔 variant를 적용하여 색 지정을 더 쉽게 만들었습니다.

### 스크린샷 또는 구동 연상(선택)
페이지 접근 권한이 없을 경우 열리는 모달 예시입니다.

기존(alert)

https://github.com/user-attachments/assets/c4fc812a-1fc8-4f22-8ce0-4adccb976470

적용(modal)

https://github.com/user-attachments/assets/0d9853a5-4a2b-43ad-b8e8-94c239c398ea


## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

코드에 대해서나 기능에 대해서 궁금한 것이 있으면 말씀해주세요!