### PR TITLE
fix: 여행 수정 성공 시, 모달 버튼 동작 안하는 문제 해결

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Modal from '@components/Modal/Modal';
 
 type OpenModalOptions = {
@@ -47,11 +47,11 @@ export default function useModal(initialOptions?: InitialModalOptions) {
     };
   });
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setState(prev => ({ ...prev, isOpen: false }));
-  };
+  }, []);
 
-  const openModal = (options: OpenModalOptions) => {
+  const openModal = useCallback((options: OpenModalOptions) => {
     setState({
       isOpen: true,
       title: options.title ?? '확인',
@@ -61,7 +61,7 @@ export default function useModal(initialOptions?: InitialModalOptions) {
       onConfirm: options.onConfirm,
       onCancel: options.onCancel,
     });
-  };
+  }, []);
 
   const handleConfirm = () => {
     state.onConfirm?.();

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -49,12 +49,12 @@ export default function SelectThumbnailPageForEdit() {
         title: '여행 수정 성공',
         message: `성공적으로 여행을 수정했습니다.${'\n'}여행페이지로 이동합니다.`,
         onCancel: () =>
-          navigate(`/travel/${data}`, {
+          navigate(`/travel/${state.travel.travelId}`, {
             viewTransition: true,
             state: { forward: true },
           }),
         onConfirm: () =>
-          navigate(`/travel/${data}`, {
+          navigate(`/travel/${state.travel.travelId}`, {
             viewTransition: true,
             state: { forward: true },
           }),


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#61 의 모달 버튼이 동작 안하는 문제를 해결했습니다.
원인은 컴포넌트 렌더링마다 `useEffect` 의존성 배열의 `openModal` 함수의 레퍼런스 값이 계속 바뀌기 때문에 Effect 코드가 계속 실행되어 openModal 함수가 무한호출 되는 것이었습니다. 그에 따라 useCallback 훅을 사용하여 `openModal` 함수 레퍼런스 값이 캐시되게 하여 무한 호출을 방지하였습니다.

또한 모달 버튼의 링크 역시 수정하여 수정한 여행 페이지로 정상적으로 이동할 수 있게 고쳤습니다.
