### PR TITLE
fix: 사진 없을 경우 에러 페이지 대신 텍스트 보여주기

### DIFF
--- a/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
+++ b/src/pages/TravelPhotoComment/TravelPhotoComment.tsx
@@ -180,12 +180,12 @@ export default function TravelPhotoComment() {
     }
   }, [commentText]);
 
-  if (travelLoading) return <div>Loading...</div>;
   if (travelError)
     return <ErrorPage status={travelStatus} message={travelError} />;
-  if (!travel || !photo)
-    return <ErrorPage status={404} message="No data found." />;
-
+  if (travelLoading) return <div>Loading...</div>;
+  if (!photo) {
+    return <div>사진 없음</div>;
+  }
   const datedPhotoData: DatedPhotoData = {
     id: photo.photoId ?? Number(photoId),
     url: photo.url || '',


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#62 404에러 페이지가 깜짝 등장하는 대신 로딩 텍스트 크기의 텍스트를 보여주게 수정했습니다.
다만, 임시 방편적인 조치에 가까워서 추후 전반적인 에러 및 로딩 처리에 대한 리팩토링이 필요할 것 같습니다.  