### PR TITLE
fix: 각종 트랜지션 수정

### DIFF
--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -17,7 +17,12 @@ const ProtectedRoute = () => {
           cancelText: '취소',
           confirmText: '확인',
           onCancel: () => navigate('/error/401', { replace: true }),
-          onConfirm: () => navigate('/login', { replace: true }),
+          onConfirm: () =>
+            navigate('/login', {
+              viewTransition: true,
+              state: { forward: true },
+              replace: true,
+            }),
         }
       : undefined
   );

--- a/src/pages/LogInPage/LogInPage.tsx
+++ b/src/pages/LogInPage/LogInPage.tsx
@@ -34,7 +34,7 @@ export default function LogInPage() {
         localStorage.setItem('accessToken', token.access_token);
 
         // 메인 페이지로 이동
-        navigate('/', {
+        navigate('/my-travel', {
           viewTransition: true,
           state: { forward: true },
         });

--- a/src/pages/MapPage/MapPage.tsx
+++ b/src/pages/MapPage/MapPage.tsx
@@ -57,23 +57,30 @@ export default function MapPage() {
   const handleMarkerClick = async (photoId: number) => {
     try {
       const token = localStorage.getItem('accessToken') || '';
-      
+
       // We must find the travelId that contains this photoId
       // because the photo object doesn't have travelId and TravelPhotoComment requires it.
-      const travelsRes = await import('../../apis/services/travel').then(m => m.travelService.getTravels(token));
+      const travelsRes = await import('../../apis/services/travel').then(m =>
+        m.travelService.getTravels(token)
+      );
       if (!travelsRes.data) return;
 
       for (const travel of travelsRes.data) {
-        const detailRes = await import('../../apis/services/travel').then(m => m.travelService.getTravel(travel.travelId, token));
+        const detailRes = await import('../../apis/services/travel').then(m =>
+          m.travelService.getTravel(travel.travelId, token)
+        );
         if (detailRes.data) {
           const allPhotos = detailRes.data.days.flatMap(day => day.photos);
           if (allPhotos.find(p => p.photoId === photoId)) {
-            navigate(`/travel/${travel.travelId}/photos/${photoId}/travel-photo-comment`);
+            navigate(
+              `/travel/${travel.travelId}/photos/${photoId}/travel-photo-comment`,
+              { viewTransition: true, state: { forward: true } }
+            );
             return;
           }
         }
       }
-      
+
       alert('이 사진이 포함된 여행을 찾을 수 없습니다.');
     } catch (e) {
       console.error(e);
@@ -87,18 +94,18 @@ export default function MapPage() {
         <BackButton onClick={handleBackClick} />
       </div>
 
-            <BackgroundMap className={classes.map} position={mapCenter}>
-                {photos.map(photo =>
-                    photo.latitude && photo.longitude ? (
-                        <PhotoMarker
-                            key={photo.photoId}
-                            position={[photo.latitude, photo.longitude]}
-                            photoUrl={photo.thumbnailUrl}
-                            onClick={() => photo.photoId && handleMarkerClick(photo.photoId)}
-                        />
-                    ) : null
-                )}
-            </BackgroundMap>
+      <BackgroundMap className={classes.map} position={mapCenter}>
+        {photos.map(photo =>
+          photo.latitude && photo.longitude ? (
+            <PhotoMarker
+              key={photo.photoId}
+              position={[photo.latitude, photo.longitude]}
+              photoUrl={photo.thumbnailUrl}
+              onClick={() => photo.photoId && handleMarkerClick(photo.photoId)}
+            />
+          ) : null
+        )}
+      </BackgroundMap>
 
       <NavigationBar nowTab="map" />
     </div>

--- a/src/pages/MyTravelPage/MyTravelPage.tsx
+++ b/src/pages/MyTravelPage/MyTravelPage.tsx
@@ -26,7 +26,7 @@ export default function MyTravelPage() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onCancel: () => navigate('/error/401'),
         onConfirm: () =>
           navigate('/login', {
             viewTransition: true,

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -18,7 +18,7 @@ export default function SelectThumbnailPage() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onCancel: () => navigate('/error/401'),
         onConfirm: () =>
           navigate('/login', {
             viewTransition: true,

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -22,7 +22,7 @@ export default function SelectThumbnailPageForEdit() {
       openModal({
         title: '권한없음',
         message: '로그인이 필요한 서비스입니다.',
-        onCancel: () => navigate('/error/401', { viewTransition: true }),
+        onCancel: () => navigate('/error/401'),
         onConfirm: () =>
           navigate('/login', {
             viewTransition: true,

--- a/src/pages/TravelPage/TravelPage.tsx
+++ b/src/pages/TravelPage/TravelPage.tsx
@@ -103,7 +103,12 @@ export default function TravelPage() {
   };
 
   const handlePhotoClick = (photoId: string | number) => {
-    navigate(`/travel/${travelId}/photos/${photoId}/travel-photo-comment`);
+    navigate(`/travel/${travelId}/photos/${photoId}/travel-photo-comment`, {
+      viewTransition: true,
+      state: {
+        forward: true,
+      },
+    });
   };
 
   const handleBackClick = () => navigate(-1);


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#63 에서 설명드렸던 사진 마커 클릭 시 트랜지션 효과 부여, 로그인 시 오른쪽으로 트랜지션을 적용했습니다.
추가적으로 오류 모달에서 취소 버튼을 클릭했을 때는 트랜지션 효과가 없는 것이 더 자연스러울 것 같아 적용했습니다.

### 스크린샷 또는 구동 연상(선택)

1. 지도 페이지에서의 사진 마커 클릭 시 트랜지션

https://github.com/user-attachments/assets/50881d09-a5cc-4dbd-8d61-eb7eb80af29e

2. 여행 페이지에서 사진 마커 클릭 시 트랜지션

https://github.com/user-attachments/assets/0ae1e43f-3379-45a7-9163-1fcc21c2d684

3. 로그인 시 오른쪽으로 트랜지션

https://github.com/user-attachments/assets/a33d868c-b8c8-4e1f-baa4-8316388e12f1

4. 오류 모달에서 취소 버튼 클릭 시, 트랜지션 없이 이동


https://github.com/user-attachments/assets/1ecf4dd9-44c4-4a27-95f9-225ae4e80048



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
