### PR TITLE
fix: UI 이슈 해결

### DIFF
--- a/src/components/DatePhotoGrid/DatePhotoGrid.module.css
+++ b/src/components/DatePhotoGrid/DatePhotoGrid.module.css
@@ -1,6 +1,6 @@
 .container {
   overflow: scroll;
-  height: 35vh;
+  height: 32.5vh;
   -ms-overflow-style: none;
   display: flex;
   flex-direction: column;

--- a/src/components/Modal/DatetimeModal/DatetimeModal.module.css
+++ b/src/components/Modal/DatetimeModal/DatetimeModal.module.css
@@ -70,8 +70,8 @@
 
 .cancelButton,
 .confirmButton {
-  width: 59px;
-  height: 32px;
+  min-width: 59px;
+  min-height: 32px;
   border-radius: 5px;
   border: none;
   font-weight: 700;

--- a/src/components/Modal/DeleteConfirmModal.module.css
+++ b/src/components/Modal/DeleteConfirmModal.module.css
@@ -18,7 +18,6 @@
   flex-direction: column;
   justify-content: space-between;
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
-  font-family: 'Inter', sans-serif;
 }
 
 .modalMessage {
@@ -48,11 +47,10 @@
 
 .cancelButton,
 .confirmDeleteButton {
-  width: 59px;
-  height: 32px;
+  min-width: 59px;
+  min-height: 32px;
   border-radius: 5px;
   border: none;
-  font-family: 'Inter', sans-serif;
   font-weight: 700;
   font-size: 16px;
   line-height: 100%;
@@ -66,7 +64,5 @@
 }
 
 .confirmDeleteButton {
-  background: #F62424;
+  background: #f62424;
 }
-
-

--- a/src/components/Modal/ShareModal.module.css
+++ b/src/components/Modal/ShareModal.module.css
@@ -18,7 +18,6 @@
   flex-direction: column;
   justify-content: space-between;
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
-  font-family: 'Inter', sans-serif;
   gap: 16px;
 }
 
@@ -34,7 +33,7 @@
   width: 269px;
   height: 43px;
   border-radius: 5px;
-  background: #F5F5F5;
+  background: #f5f5f5;
   display: flex;
   align-items: center;
   align-self: center;
@@ -75,11 +74,10 @@
 
 .cancelButton,
 .copyButton {
-  width: 59px;
-  height: 32px;
+  min-width: 59px;
+  min-height: 32px;
   border-radius: 5px;
   border: none;
-  font-family: 'Inter', sans-serif;
   font-weight: 700;
   font-size: 16px;
   line-height: 100%;
@@ -93,7 +91,7 @@
 }
 
 .copyButton {
-  background: #0D9EFF;
+  background: #0d9eff;
 }
 
 .copyToast {
@@ -110,10 +108,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-family: 'Inter', sans-serif;
   font-weight: 700;
   font-size: 20px;
   line-height: 100%;
   text-align: center;
 }
-

--- a/src/pages/EditTravelHome/EditTravelHome.module.css
+++ b/src/pages/EditTravelHome/EditTravelHome.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  row-gap: 16px;
+  row-gap: 8px;
 }
 .uploadDescription {
   text-align: center;
@@ -28,6 +28,10 @@
   font-size: 14px;
   margin: 0px 0px;
   text-align: center;
+}
+
+.invisible {
+  visibility: hidden;
 }
 
 .backButton {
@@ -70,7 +74,10 @@
   row-gap: 8px;
 }
 .button {
-  margin: 5% auto;
+  transform: translateX(-50%);
+  left: 50%;
+  bottom: 7%;
+  position: absolute;
 }
 .photoSelectButton {
   margin: 0 auto;

--- a/src/pages/EditTravelHome/EditTravelHome.tsx
+++ b/src/pages/EditTravelHome/EditTravelHome.tsx
@@ -136,9 +136,12 @@ export default function EditTravelHome() {
               id="travel-name"
               autoComplete="off"
             />
-            {titleErrorText !== '' && (
-              <p className={classes.titleErrorHelperText}>{titleErrorText}</p>
-            )}
+
+            <p
+              className={`${classes.titleErrorHelperText} ${titleErrorText === '' ? classes.invisible : ''}`}
+            >
+              {titleErrorText === '' ? '오류 없음' : titleErrorText}
+            </p>
           </section>
           <section className={classes.inputSection}>
             <h3 className={classes.inputHeader}>여행 사진</h3>
@@ -148,15 +151,19 @@ export default function EditTravelHome() {
             >
               사진 업로드
             </FileSelectButton>
-            {photoErrorText !== '' && (
-              <p className={classes.photoErrorHelperText}>{photoErrorText}</p>
-            )}
           </section>
-          <p className={classes.uploadDescription}>
-            사진 위치 정보가 없으면 위치가 표시 되지 않습니다.
-            <br />
-            (카카오톡 사진 전송시, 원본 사진 요망)
-          </p>
+          <div>
+            <p className={classes.uploadDescription}>
+              사진 위치 정보가 없으면 위치가 표시 되지 않습니다.
+              <br />
+              (카카오톡 사진 전송시, 원본 사진 요망)
+            </p>
+            <p
+              className={`${classes.photoErrorHelperText} ${photoErrorText === '' ? classes.invisible : ''}`}
+            >
+              {photoErrorText === '' ? '오류 없음' : photoErrorText}
+            </p>
+          </div>
 
           <DatePhotoGrid photos={travel ? travel.photos : []} />
           <Button className={classes.button} onClick={handleClickNextButton}>

--- a/src/pages/NewTravelHome/NewTravelHome.module.css
+++ b/src/pages/NewTravelHome/NewTravelHome.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  row-gap: 16px;
+  row-gap: 8px;
 }
 .uploadDescription {
   text-align: center;
@@ -28,6 +28,10 @@
   font-size: 14px;
   margin: 0px 0px;
   text-align: center;
+}
+
+.invisible {
+  visibility: hidden;
 }
 
 .backButton {
@@ -70,7 +74,10 @@
   row-gap: 8px;
 }
 .button {
-  margin: 5% auto;
+  transform: translateX(-50%);
+  left: 50%;
+  bottom: 7%;
+  position: absolute;
 }
 .photoSelectButton {
   margin: 0 auto;

--- a/src/pages/NewTravelHome/NewTravelHome.tsx
+++ b/src/pages/NewTravelHome/NewTravelHome.tsx
@@ -134,9 +134,11 @@ export default function NewTravelHome() {
           id="travel-name"
           autoComplete="off"
         />
-        {titleErrorText !== '' && (
-          <p className={classes.titleErrorHelperText}>{titleErrorText}</p>
-        )}
+        <p
+          className={`${classes.titleErrorHelperText} ${titleErrorText === '' ? classes.invisible : ''}`}
+        >
+          {titleErrorText === '' ? '오류 없음' : titleErrorText}
+        </p>
       </section>
       <section className={classes.inputSection}>
         <h3 className={classes.inputHeader}>여행 사진</h3>
@@ -146,15 +148,19 @@ export default function NewTravelHome() {
         >
           사진 업로드
         </FileSelectButton>
-        {photoErrorText !== '' && (
-          <p className={classes.photoErrorHelperText}>{photoErrorText}</p>
-        )}
       </section>
-      <p className={classes.uploadDescription}>
-        사진 위치 정보가 없으면 위치가 표시 되지 않습니다.
-        <br />
-        (카카오톡 사진 전송시, 원본 사진 요망)
-      </p>
+      <div>
+        <p className={classes.uploadDescription}>
+          사진 위치 정보가 없으면 위치가 표시 되지 않습니다.
+          <br />
+          (카카오톡 사진 전송시, 원본 사진 요망)
+        </p>
+        <p
+          className={`${classes.photoErrorHelperText} ${photoErrorText === '' ? classes.invisible : ''}`}
+        >
+          {photoErrorText === '' ? '오류 없음' : photoErrorText}
+        </p>
+      </div>
 
       <DatePhotoGrid photos={travel.photos} />
       <Button className={classes.button} onClick={handleClickNextButton}>

--- a/src/pages/NewTravelPhotoPage/NewTravelPhotoPage.module.css
+++ b/src/pages/NewTravelPhotoPage/NewTravelPhotoPage.module.css
@@ -1,9 +1,9 @@
 .header {
   color: white;
   display: flex;
-  padding-block: 5vh;
-  padding-inline: 22px;
-  width: calc(100% - (22px * 2));
+  padding-top: 75px;
+  padding-inline: 24px;
+  width: calc(100% - (24px * 2));
   justify-content: space-between;
   background-color: rgba(0, 0, 0, 0.4);
   position: fixed;

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.module.css
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.module.css
@@ -27,7 +27,10 @@
 }
 
 .button {
-  margin: 5% auto;
+  transform: translateX(-50%);
+  left: 50%;
+  bottom: 7%;
+  position: absolute;
 }
 
 .button:disabled {

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.module.css
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.module.css
@@ -41,6 +41,9 @@
 }
 
 .loadingMessage {
+  text-align: center;
+  word-break: keep-all;
+  width: 75%;
   min-height: 24px;
   margin: 0 auto;
   color: #5a5a5a;

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -94,16 +94,6 @@ export default function SelectThumbnailPage() {
       >
         {loading ? '여행 추가 중...' : '여행 추가'}
       </Button>
-      <p className={classes.loadingMessage} role="status" aria-live="polite">
-        {loading ? (
-          <>
-            여행을 추가하고 있어요. <br /> 완료되면 자동으로 여행 페이지로
-            이동해요.
-          </>
-        ) : (
-          ''
-        )}
-      </p>
       {modalElement}
     </div>
   );

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -95,9 +95,14 @@ export default function SelectThumbnailPage() {
         {loading ? '여행 추가 중...' : '여행 추가'}
       </Button>
       <p className={classes.loadingMessage} role="status" aria-live="polite">
-        {loading
-          ? '여행을 생성하고 있어요. 완료되면 자동으로 여행 페이지로 이동해요.'
-          : ''}
+        {loading ? (
+          <>
+            여행을 추가하고 있어요. <br /> 완료되면 자동으로 여행 페이지로
+            이동해요.
+          </>
+        ) : (
+          ''
+        )}
       </p>
       {modalElement}
     </div>

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.module.css
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.module.css
@@ -35,6 +35,9 @@
   margin: 0px;
 }
 .loadingMessage {
+  text-align: center;
+  word-break: keep-all;
+  width: 75%;
   min-height: 24px;
   margin: 0 auto;
   color: #5a5a5a;

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.module.css
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.module.css
@@ -27,7 +27,10 @@
 }
 
 .button {
-  margin: 5% auto;
+  transform: translateX(-50%);
+  left: 50%;
+  bottom: 7%;
+  position: absolute;
 }
 
 .uploadDescription {

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -98,9 +98,14 @@ export default function SelectThumbnailPageForEdit() {
         {loading ? '여행 수정 중...' : '여행 수정'}
       </Button>
       <p className={classes.loadingMessage} role="status" aria-live="polite">
-        {loading
-          ? '여행을 수정하고 있어요. 완료되면 자동으로 여행 페이지로 이동해요.'
-          : ''}
+        {loading ? (
+          <>
+            여행을 수정하고 있어요. <br /> 완료되면 자동으로 여행 페이지로
+            이동해요.
+          </>
+        ) : (
+          ''
+        )}
       </p>
       {modalElement}
     </div>

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -97,16 +97,6 @@ export default function SelectThumbnailPageForEdit() {
       >
         {loading ? '여행 수정 중...' : '여행 수정'}
       </Button>
-      <p className={classes.loadingMessage} role="status" aria-live="polite">
-        {loading ? (
-          <>
-            여행을 수정하고 있어요. <br /> 완료되면 자동으로 여행 페이지로
-            이동해요.
-          </>
-        ) : (
-          ''
-        )}
-      </p>
       {modalElement}
     </div>
   );

--- a/src/pages/SelectThumbnailPhotoPage/SelectThumbnailPhotoPage.module.css
+++ b/src/pages/SelectThumbnailPhotoPage/SelectThumbnailPhotoPage.module.css
@@ -1,9 +1,9 @@
 .header {
   color: white;
   display: flex;
-  padding-block: 5vh;
-  padding-inline: 22px;
-  width: calc(100% - (22px * 2));
+  padding-top: 75px;
+  padding-inline: 24px;
+  width: calc(100% - (24px * 2));
   justify-content: space-between;
   background-color: rgba(0, 0, 0, 0.4);
   position: fixed;

--- a/src/pages/TravelPhotoComment/TravelPhotoComment.module.css
+++ b/src/pages/TravelPhotoComment/TravelPhotoComment.module.css
@@ -46,27 +46,27 @@
   left: 8px;
 }
 
-.deleteButtonWrapper {}
-
 .photoInformation {
   font-size: 16px;
-  color: #5B5B5B;
+  color: #5b5b5b;
 }
 
 .photoInformation a {
-  color: #029AFF;
+  color: #029aff;
 }
 
 .textAreaContainer {
   width: 100%;
   min-height: 140px;
   border-radius: 8px;
-  background-color: #F6F6F6;
+  background-color: #f6f6f6;
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
   padding: 16px;
+  margin-top: 21px;
+  margin-bottom: 7px;
 }
 
 .textAreaWrapper {
@@ -74,7 +74,6 @@
   background: transparent;
   border: none;
   outline: none;
-  font-family: 'Regular';
   font-size: 15px;
   line-height: 1.5;
   text-align: center;
@@ -86,8 +85,6 @@
 .textAreaWrapper::placeholder {
   text-align: center;
 }
-
-
 
 .finishButton Button {
   top: 50%;


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#64에서 말씀드렸던 여행 수정 추가 페이지의 에러에 따라 스크롤이 생기는 문제를 레이아웃 수정을 통해 해결하였고, 간격 관련 내용도 모두 수정했습니다. 추가적으로 #31의 ios webview에서 버튼 문제도 최소 크기를 지정하는 걸로 수정하여 해결하였습니다.

다만, 여행 수정 추가 페이지의 로딩 메시지의 경우 충분히 수정(추가)버튼이 `여행 수정중..` 등으로 텍스트가 바뀌고 `disabled` 상태가 되기도 하고, 화면 여백이 부족한 관계로 제거하는 것으로 결정하고 진행했습니다.
 

### 스크린샷 또는 구동 연상(선택)

1. 여행 수정, 추가 페이지 레이아웃 수정


https://github.com/user-attachments/assets/b84db8bf-dda1-4454-acd8-87978e89e127



2. 전체 사진 페이지 상단 여백 수정
<img width="451" height="911" alt="스크린샷 2026-03-28 오후 11 37 48" src="https://github.com/user-attachments/assets/2bbed89a-960f-47cf-bedc-41c74bed3cf4" />

3. 여행 수정, 추가 로딩 메시지 제거
<img width="290" height="635" alt="스크린샷 2026-03-29 오전 12 03 03" src="https://github.com/user-attachments/assets/7d503de7-5c4d-4c6f-ab8b-9f6dd65f6279" />

4. ios webview 버튼 글자 줄 바꿈 문제 해결
<img width="361" height="294" alt="스크린샷 2026-03-28 오후 11 48 37" src="https://github.com/user-attachments/assets/51baa079-ee68-4806-a401-29aa84cf055b" />
<img width="347" height="196" alt="스크린샷 2026-03-28 오후 11 48 44" src="https://github.com/user-attachments/assets/eb86a4f9-dc17-4f17-90f7-9b760595811a" />



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
