### PR TITLE
fix: 파일 `accept` 속성 제거

### DIFF
--- a/src/components/Buttons/FileSelectButton/FileSelectButton.tsx
+++ b/src/components/Buttons/FileSelectButton/FileSelectButton.tsx
@@ -5,7 +5,7 @@ export default function FileSelectButton({
   onChange,
   children,
   id = 'select-photo',
-  accept = 'image/*',
+  accept = '',
   multiple = true,
   className = '',
   ...props


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#72 의 문제를 해결하기위해 exifreader repository의 이슈 코멘트 중 
파일 인풋에 `accept` 속성의 값을 없애면 정상적으로 작동한다는 코멘트를 보고 적용하였고, 동작에 이상이 없어 PR합니다.
(아마 안드로이드의 프라이버시 관련 처리로 인해 gps 속성이 제거된다는 의견이 있습니다)

관련 이슈 코멘트
https://github.com/mattiasw/ExifReader/issues/378#issuecomment-2302705983