### PR TITLE
fix: 여행 정보가 없거나 비었으면 내 여행 목록 페이지로 이동하기

### DIFF
--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -30,11 +30,6 @@ export default function SelectThumbnailPage() {
     request(travel, token);
   };
 
-  const isValidTravelForThumbnail =
-    travel.title.trim() !== '' && travel.photos.length > 0;
-  if (!isValidTravelForThumbnail) {
-    return <Navigate to="/my-travel" />;
-  }
   useEffect(() => {
     if (loading) {
       return;
@@ -63,6 +58,11 @@ export default function SelectThumbnailPage() {
       });
     }
   }, [error, loading, data]);
+  const isValidTravelForThumbnail =
+    travel.title.trim() !== '' && travel.photos.length > 0;
+  if (!isValidTravelForThumbnail) {
+    return <Navigate to="/my-travel" />;
+  }
   const thumbnailCheckedPhotos = travel.photos.map(photo => {
     return {
       ...photo,

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -1,5 +1,5 @@
 import classes from './SelectThumbnailPage.module.css';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import BlackBackIcon from '@assets/icons/back-black.svg';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import Button from '@components/Buttons/Button/Button';
@@ -29,6 +29,12 @@ export default function SelectThumbnailPage() {
     }
     request(travel, token);
   };
+
+  const isValidTravelForThumbnail =
+    travel.title.trim() !== '' && travel.photos.length > 0;
+  if (!isValidTravelForThumbnail) {
+    return <Navigate to="/my-travel" />;
+  }
   useEffect(() => {
     if (loading) {
       return;

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -33,9 +33,6 @@ export default function SelectThumbnailPageForEdit() {
     }
     request(state.travel.travelId, travel, token);
   };
-  if (!travel) {
-    return <Navigate to={'/my-travel'} />;
-  }
   useEffect(() => {
     if (loading) {
       return;
@@ -64,6 +61,9 @@ export default function SelectThumbnailPageForEdit() {
       });
     }
   }, [loading, error, data, navigate, openModal, state.travelId]);
+  if (!travel) {
+    return <Navigate to={'/my-travel'} />;
+  }
   const thumbnailCheckedPhotos = travel.photos.map(photo => {
     return {
       ...photo,

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -1,5 +1,5 @@
 import classes from './SelectThumbnailPageForEdit.module.css';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import BlackBackIcon from '@assets/icons/back-black.svg';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import Button from '@components/Buttons/Button/Button';
@@ -33,6 +33,9 @@ export default function SelectThumbnailPageForEdit() {
     }
     request(state.travel.travelId, travel, token);
   };
+  if (!travel) {
+    return <Navigate to={'/my-travel'} />;
+  }
   useEffect(() => {
     if (loading) {
       return;


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#74 만약 여행 수정 데이터가 없거나, 여행 추가 데이터가 비었으면, 대표사진 선택 페이지에서 내 여행목록 페이지로 이동하게 수정했습니다.

### 스크린샷 또는 구동 연상(선택)

여행 수정

https://github.com/user-attachments/assets/4c24713f-ba3c-46c8-8496-9e322b5bc94c




여행 추가

https://github.com/user-attachments/assets/c08b5d96-69d9-4be6-af11-f8167f3efb38
