### PR TITLE
feat: 사진 피커 사용을 위한 사진 추가 웹뷰 처리

### DIFF
--- a/src/components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton.module.css
+++ b/src/components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton.module.css
@@ -1,0 +1,3 @@
+.touchTarget {
+  touch-action: manipulation;
+}

--- a/src/components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton.tsx
+++ b/src/components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton.tsx
@@ -1,0 +1,57 @@
+import type { ButtonHTMLAttributes, MouseEvent } from 'react';
+import Button from '../Button/Button';
+import classes from './WebViewImageSelectButton.module.css';
+import type { WithReactNativeWebView } from '@utils/webview';
+
+export const WEBVIEW_IMAGE_SELECT_MESSAGE_TYPE = 'SELECT_IMAGES' as const;
+
+type WebViewImageSelectMessage = {
+  type: typeof WEBVIEW_IMAGE_SELECT_MESSAGE_TYPE;
+  allowMultiple?: boolean;
+};
+
+export type WebViewImageSelectButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'type'
+> & {
+  webviewMessage?: WebViewImageSelectMessage;
+  allowMultiple?: boolean;
+};
+
+function postImageSelectToWebView(payload: WebViewImageSelectMessage) {
+  const w = window as WithReactNativeWebView;
+  w.ReactNativeWebView?.postMessage(JSON.stringify(payload));
+}
+
+export default function WebViewImageSelectButton({
+  onClick,
+  webviewMessage,
+  allowMultiple = true,
+  className = '',
+  children,
+  ...props
+}: WebViewImageSelectButtonProps) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    const payload =
+      webviewMessage ??
+      ({
+        type: WEBVIEW_IMAGE_SELECT_MESSAGE_TYPE,
+        allowMultiple,
+      } satisfies WebViewImageSelectMessage);
+
+    postImageSelectToWebView(payload);
+    onClick?.(event);
+  };
+
+  return (
+    <Button
+      type="button"
+      className={`${classes.touchTarget} ${className}`.trim()}
+      aria-label="이미지 선택"
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/pages/EditTravelHome/EditTravelHome.tsx
+++ b/src/pages/EditTravelHome/EditTravelHome.tsx
@@ -2,7 +2,10 @@ import BlackBackIcon from '@assets/icons/back-black.svg';
 import FileSelectButton from '@components/Buttons/FileSelectButton/FileSelectButton';
 import WebViewImageSelectButton from '@components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton';
 import Button from '@components/Buttons/Button/Button';
-import type { FullPhotoData } from 'src/types/photo.type';
+import type {
+  FullPhotoData,
+  WebViewSelectImagesResultMessage,
+} from 'src/types/photo.type';
 import { isReactNativeWebView } from '@utils/webview';
 import classes from './EditTravelHome.module.css';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
@@ -10,7 +13,9 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { getCreatedDateTime, getGPSCoordinates } from 'src/utils/exif';
 import { useEditTravel } from '@hooks/travel';
 import { dateCompare } from '@utils/date';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { base64ToFile } from '@utils/photo';
+
 const checkFileExtension = (file: File, extensions: string[]) => {
   const fileExtension = file.name.split('.').pop()?.toLowerCase();
   if (fileExtension === undefined) {
@@ -32,12 +37,6 @@ export default function EditTravelHome() {
       return { ...travel, thumbnailPhotoId: id };
     });
   };
-  const setPhotos = (photos: FullPhotoData[]) => {
-    setTravel(travel => {
-      return { ...travel, photos };
-    });
-  };
-
   const setTravelTitle = (title: string) => {
     setTravel(travel => {
       return { ...travel, title: title };
@@ -108,9 +107,83 @@ export default function EditTravelHome() {
     const warnedPhotos = addedPhotos.map(photo => {
       return { ...photo, warning: photo.GPSCoordinates === null };
     });
-    const newPhotos = [...travel.photos, ...warnedPhotos];
-    setPhotos(newPhotos);
+    setTravel(currentTravel => {
+      return {
+        ...currentTravel,
+        photos: [...currentTravel.photos, ...warnedPhotos],
+      };
+    });
   };
+
+  useEffect(() => {
+    if (!isReactNativeWebView()) {
+      return;
+    }
+
+    const handleWebViewMessage = (event: MessageEvent<string> | Event) => {
+      const messageData = 'data' in event ? event.data : undefined;
+      if (typeof messageData !== 'string') {
+        return;
+      }
+
+      let parsedMessage: unknown;
+      try {
+        parsedMessage = JSON.parse(messageData);
+      } catch {
+        return;
+      }
+
+      if (
+        typeof parsedMessage !== 'object' ||
+        parsedMessage === null ||
+        !('type' in parsedMessage) ||
+        parsedMessage.type !== 'SELECT_IMAGES_RESULT' ||
+        !('photos' in parsedMessage) ||
+        !Array.isArray(parsedMessage.photos)
+      ) {
+        return;
+      }
+
+      const message = parsedMessage as WebViewSelectImagesResultMessage;
+      if (message.photos.length === 0) {
+        return;
+      }
+
+      setPhotoErrorText('');
+      const addedPhotos: FullPhotoData[] = message.photos.map(
+        (photo, index) => {
+          const fileName = `webview-photo-${Date.now()}-${index}`;
+          const file = base64ToFile(photo.photoBase64, fileName);
+          const url = URL.createObjectURL(file);
+
+          return {
+            id: Date.now(),
+            url,
+            date: photo.date,
+            GPSCoordinates: photo.GPSCoordinates,
+            link: 'photo',
+            file,
+            warning: photo.GPSCoordinates === null,
+          };
+        }
+      );
+
+      setTravel(currentTravel => {
+        return {
+          ...currentTravel,
+          photos: [...currentTravel.photos, ...addedPhotos],
+        };
+      });
+    };
+
+    const messageEventListener = handleWebViewMessage as EventListener;
+    window.addEventListener('message', messageEventListener);
+    document.addEventListener('message', messageEventListener);
+    return () => {
+      window.removeEventListener('message', messageEventListener);
+      document.removeEventListener('message', messageEventListener);
+    };
+  }, [setTravel]);
   return (
     <div className={classes.container}>
       <header className={classes.header}>

--- a/src/pages/EditTravelHome/EditTravelHome.tsx
+++ b/src/pages/EditTravelHome/EditTravelHome.tsx
@@ -1,7 +1,9 @@
 import BlackBackIcon from '@assets/icons/back-black.svg';
 import FileSelectButton from '@components/Buttons/FileSelectButton/FileSelectButton';
+import WebViewImageSelectButton from '@components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton';
 import Button from '@components/Buttons/Button/Button';
 import type { FullPhotoData } from 'src/types/photo.type';
+import { isReactNativeWebView } from '@utils/webview';
 import classes from './EditTravelHome.module.css';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -145,12 +147,18 @@ export default function EditTravelHome() {
           </section>
           <section className={classes.inputSection}>
             <h3 className={classes.inputHeader}>여행 사진</h3>
-            <FileSelectButton
-              className={classes.photoSelectButton}
-              onChange={handleFileChange}
-            >
-              사진 업로드
-            </FileSelectButton>
+            {isReactNativeWebView() ? (
+              <WebViewImageSelectButton className={classes.photoSelectButton}>
+                사진 업로드
+              </WebViewImageSelectButton>
+            ) : (
+              <FileSelectButton
+                className={classes.photoSelectButton}
+                onChange={handleFileChange}
+              >
+                사진 업로드
+              </FileSelectButton>
+            )}
           </section>
           <div>
             <p className={classes.uploadDescription}>

--- a/src/pages/EditTravelHome/EditTravelHome.tsx
+++ b/src/pages/EditTravelHome/EditTravelHome.tsx
@@ -157,7 +157,7 @@ export default function EditTravelHome() {
           const url = URL.createObjectURL(file);
 
           return {
-            id: Date.now(),
+            id: new URL(url.slice(5)).pathname.slice(1),
             url,
             date: photo.date,
             GPSCoordinates: photo.GPSCoordinates,

--- a/src/pages/NewTravelHome/NewTravelHome.tsx
+++ b/src/pages/NewTravelHome/NewTravelHome.tsx
@@ -2,15 +2,20 @@ import BlackBackIcon from '@assets/icons/back-black.svg';
 import FileSelectButton from '@components/Buttons/FileSelectButton/FileSelectButton';
 import WebViewImageSelectButton from '@components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton';
 import Button from '@components/Buttons/Button/Button';
-import type { FullPhotoData } from 'src/types/photo.type';
+import type {
+  FullPhotoData,
+  WebViewSelectImagesResultMessage,
+} from 'src/types/photo.type';
 import { isReactNativeWebView } from '@utils/webview';
 import classes from './NewTravelHome.module.css';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import { useNavigate } from 'react-router-dom';
 import { getCreatedDateTime, getGPSCoordinates } from 'src/utils/exif';
 import { useTravel } from '@hooks/travel';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { dateCompare } from '@utils/date';
+import { base64ToFile } from '@utils/photo';
+
 const checkFileExtension = (file: File, extensions: string[]) => {
   const fileExtension = file.name.split('.').pop()?.toLowerCase();
   if (fileExtension === undefined) {
@@ -25,12 +30,6 @@ export default function NewTravelHome() {
 
   const [titleErrorText, setTitleErrorText] = useState('');
   const [photoErrorText, setPhotoErrorText] = useState('');
-
-  const setPhotos = (photos: FullPhotoData[]) => {
-    setTravel(travel => {
-      return { ...travel, photos };
-    });
-  };
 
   const setThumbnailPhotoId = (id: number | string) => {
     setTravel(travel => {
@@ -110,9 +109,82 @@ export default function NewTravelHome() {
     const warnedPhotos = addedPhotos.map(photo => {
       return { ...photo, warning: photo.GPSCoordinates === null };
     });
-    const newPhotos = [...travel.photos, ...warnedPhotos];
-    setPhotos(newPhotos);
+    setTravel(currentTravel => {
+      return {
+        ...currentTravel,
+        photos: [...currentTravel.photos, ...warnedPhotos],
+      };
+    });
   };
+
+  useEffect(() => {
+    if (!isReactNativeWebView()) {
+      return;
+    }
+
+    const handleWebViewMessage = (event: MessageEvent<string> | Event) => {
+      const messageData = 'data' in event ? event.data : undefined;
+      if (typeof messageData !== 'string') {
+        return;
+      }
+      let parsedMessage: unknown;
+      try {
+        parsedMessage = JSON.parse(messageData);
+      } catch {
+        return;
+      }
+
+      if (
+        typeof parsedMessage !== 'object' ||
+        parsedMessage === null ||
+        !('type' in parsedMessage) ||
+        parsedMessage.type !== 'SELECT_IMAGES_RESULT' ||
+        !('photos' in parsedMessage) ||
+        !Array.isArray(parsedMessage.photos)
+      ) {
+        return;
+      }
+
+      const message = parsedMessage as WebViewSelectImagesResultMessage;
+      if (message.photos.length === 0) {
+        return;
+      }
+
+      setPhotoErrorText('');
+      const addedPhotos: FullPhotoData[] = message.photos.map(
+        (photo, index) => {
+          const fileName = `webview-photo-${Date.now()}-${index}`;
+          const file = base64ToFile(photo.photoBase64, fileName);
+          const url = URL.createObjectURL(file);
+          const blobId = new URL(url.slice(5)).pathname.slice(1);
+          return {
+            id: blobId,
+            url,
+            date: photo.date,
+            GPSCoordinates: photo.GPSCoordinates,
+            link: 'photo',
+            file,
+            warning: photo.GPSCoordinates === null,
+          };
+        }
+      );
+
+      setTravel(currentTravel => {
+        return {
+          ...currentTravel,
+          photos: [...currentTravel.photos, ...addedPhotos],
+        };
+      });
+    };
+
+    const messageEventListener = handleWebViewMessage as EventListener;
+    window.addEventListener('message', messageEventListener);
+    document.addEventListener('message', messageEventListener);
+    return () => {
+      window.removeEventListener('message', messageEventListener);
+      document.removeEventListener('message', messageEventListener);
+    };
+  }, [setTravel]);
   return (
     <div className={classes.container}>
       <header className={classes.header}>

--- a/src/pages/NewTravelHome/NewTravelHome.tsx
+++ b/src/pages/NewTravelHome/NewTravelHome.tsx
@@ -1,7 +1,9 @@
 import BlackBackIcon from '@assets/icons/back-black.svg';
 import FileSelectButton from '@components/Buttons/FileSelectButton/FileSelectButton';
+import WebViewImageSelectButton from '@components/Buttons/WebViewImageSelectButton/WebViewImageSelectButton';
 import Button from '@components/Buttons/Button/Button';
 import type { FullPhotoData } from 'src/types/photo.type';
+import { isReactNativeWebView } from '@utils/webview';
 import classes from './NewTravelHome.module.css';
 import DatePhotoGrid from '@components/DatePhotoGrid/DatePhotoGrid';
 import { useNavigate } from 'react-router-dom';
@@ -142,12 +144,18 @@ export default function NewTravelHome() {
       </section>
       <section className={classes.inputSection}>
         <h3 className={classes.inputHeader}>여행 사진</h3>
-        <FileSelectButton
-          className={classes.photoSelectButton}
-          onChange={handleFileChange}
-        >
-          사진 업로드
-        </FileSelectButton>
+        {isReactNativeWebView() ? (
+          <WebViewImageSelectButton className={classes.photoSelectButton}>
+            사진 업로드
+          </WebViewImageSelectButton>
+        ) : (
+          <FileSelectButton
+            className={classes.photoSelectButton}
+            onChange={handleFileChange}
+          >
+            사진 업로드
+          </FileSelectButton>
+        )}
       </section>
       <div>
         <p className={classes.uploadDescription}>

--- a/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
+++ b/src/pages/SelectThumbnailPage/SelectThumbnailPage.tsx
@@ -42,6 +42,7 @@ export default function SelectThumbnailPage() {
       return;
     }
     if (data) {
+      travel.photos.forEach(({ url }) => URL.revokeObjectURL(url));
       openModal({
         title: '여행 생성 성공',
         message: `성공적으로 여행을 생성했습니다.${'\n'}여행페이지로 이동합니다.`,

--- a/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
+++ b/src/pages/SelectThumbnailPageForEdit/SelectThumbnailPageForEdit.tsx
@@ -45,6 +45,12 @@ export default function SelectThumbnailPageForEdit() {
       return;
     }
     if (data) {
+      travel.photos.forEach(({ url }) => {
+        if (url.startsWith('blob:')) {
+          URL.revokeObjectURL(url);
+        }
+      });
+
       openModal({
         title: '여행 수정 성공',
         message: `성공적으로 여행을 수정했습니다.${'\n'}여행페이지로 이동합니다.`,

--- a/src/types/photo.type.ts
+++ b/src/types/photo.type.ts
@@ -14,6 +14,17 @@ export interface FullPhotoData extends DatedPhotoData {
   GPSCoordinates: { latitude: number; longitude: number } | null;
 }
 
+export interface WebViewPhoto {
+  photoBase64: string;
+  GPSCoordinates: { latitude: number; longitude: number } | null;
+  date: string | null;
+}
+
+export interface WebViewSelectImagesResultMessage {
+  type: 'SELECT_IMAGES_RESULT';
+  photos: WebViewPhoto[];
+}
+
 export interface uploadedPhoto {
   id: number;
   url: string;

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -38,3 +38,17 @@ export async function photoFileToWebp(photoFile: File) {
     image.src = imageURL;
   });
 }
+
+export const base64ToFile = (base64: string, fileName: string) => {
+  const [header, data] = base64.split(',');
+  const hasDataUrlHeader = base64.includes(',');
+  const mimeType = hasDataUrlHeader
+    ? (header.match(/data:(.*?);base64/)?.[1] ?? 'image/jpeg')
+    : 'image/jpeg';
+  const base64Data = hasDataUrlHeader ? data : base64;
+  const binaryString = atob(base64Data);
+  const byteArray = Uint8Array.from(binaryString, char => char.charCodeAt(0));
+  const extension = mimeType.split('/')[1] ?? 'jpg';
+
+  return new File([byteArray], `${fileName}.${extension}`, { type: mimeType });
+};

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -1,0 +1,7 @@
+export type WithReactNativeWebView = Window & {
+  ReactNativeWebView?: { postMessage: (message: string) => void };
+};
+
+export function isReactNativeWebView(): boolean {
+  return Boolean((window as WithReactNativeWebView).ReactNativeWebView);
+}


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

여행 추가 및 수정 페이지에서 #72 안드로이드 웹뷰 특정 버전의 경우 exif에 있는 사진 GPS 데이터가 사라지는 문제가 아직 존재합니다.
따라서 현재 화면이 웹뷰 화면일 때, 리액트 네이티브 웹뷰로 신호를 주고, 리액트 네이티브에서 expo-photo-picker로 얻은 사진 데이터를 처리해서 웹뷰로 메시지를 통해 전송하면, 웹뷰에서 여행 추가(수정) 상태에 추가하는 로직으로 대체하게끔 구현했습니다. 현재 PR은 웹 부분의 구현입니다.

### 스크린샷 또는 구동 연상(선택)

안드로이드 

https://github.com/user-attachments/assets/45faa503-5780-4997-ac2f-70e1bcb960a3

ios


https://github.com/user-attachments/assets/180be693-347f-4f7b-9f23-95ae96b61f75

