### PR TITLE
feat: 사진 접근 요청 거부 시 에러 메시지 적용

### DIFF
--- a/src/pages/EditTravelHome/EditTravelHome.tsx
+++ b/src/pages/EditTravelHome/EditTravelHome.tsx
@@ -136,7 +136,19 @@ export default function EditTravelHome() {
       if (
         typeof parsedMessage !== 'object' ||
         parsedMessage === null ||
-        !('type' in parsedMessage) ||
+        !('type' in parsedMessage)
+      ) {
+        return;
+      }
+      if (
+        parsedMessage.type === 'SELECT_IMAGES_ERROR' &&
+        'message' in parsedMessage &&
+        typeof parsedMessage.message === 'string'
+      ) {
+        setPhotoErrorText(parsedMessage.message);
+        return;
+      }
+      if (
         parsedMessage.type !== 'SELECT_IMAGES_RESULT' ||
         !('photos' in parsedMessage) ||
         !Array.isArray(parsedMessage.photos)

--- a/src/pages/NewTravelHome/NewTravelHome.tsx
+++ b/src/pages/NewTravelHome/NewTravelHome.tsx
@@ -137,7 +137,19 @@ export default function NewTravelHome() {
       if (
         typeof parsedMessage !== 'object' ||
         parsedMessage === null ||
-        !('type' in parsedMessage) ||
+        !('type' in parsedMessage)
+      ) {
+        return;
+      }
+      if (
+        parsedMessage.type === 'SELECT_IMAGES_ERROR' &&
+        'message' in parsedMessage &&
+        typeof parsedMessage.message === 'string'
+      ) {
+        setPhotoErrorText(parsedMessage.message);
+        return;
+      }
+      if (
         parsedMessage.type !== 'SELECT_IMAGES_RESULT' ||
         !('photos' in parsedMessage) ||
         !Array.isArray(parsedMessage.photos)

--- a/src/types/photo.type.ts
+++ b/src/types/photo.type.ts
@@ -25,6 +25,11 @@ export interface WebViewSelectImagesResultMessage {
   photos: WebViewPhoto[];
 }
 
+export interface WebViewSelectImagesErrorMessage {
+  type: 'SELECT_IMAGES_ERROR';
+  message: string;
+}
+
 export interface uploadedPhoto {
   id: number;
   url: string;


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

만약 앱에서 권한이 차단 되어 웹뷰에서 메시지가 오면, 에러메시지를 출력하게 구현하였습니다.  

### 스크린샷 또는 구동 연상(선택)

안드로이드

https://github.com/user-attachments/assets/f2fa6ff3-d002-44d0-b034-6761f9211adf

ios

https://github.com/user-attachments/assets/ab342288-3d70-4f51-8e3d-b1603b1d8596
