### PR TITLE
feat: 개인 설정 페이지 구현

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -24,6 +24,7 @@ import ErrorRoute from './pages/ErrorPage/ErrorRoute';
 
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import { Transition } from './pages/Transition/Transition';
+import SettingPage from './pages/SettingPage/SettingPage';
 
 const router = createBrowserRouter([
   {
@@ -53,6 +54,10 @@ const router = createBrowserRouter([
           {
             path: '/my-travel',
             Component: MyTravelPage,
+          },
+          {
+            path: '/setting',
+            Component: SettingPage,
           },
           {
             path: '/map',

--- a/src/assets/icons/chevron-right.svg
+++ b/src/assets/icons/chevron-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-right-icon lucide-chevron-right"><path d="m9 18 6-6-6-6"/></svg>

--- a/src/pages/MyTravelPage/MyTravelPage.module.css
+++ b/src/pages/MyTravelPage/MyTravelPage.module.css
@@ -11,7 +11,7 @@
 .headerText {
   margin: 0;
 }
-.logoutLink {
+.menuLink {
   color: #029aff;
   text-decoration: none;
 }

--- a/src/pages/MyTravelPage/MyTravelPage.tsx
+++ b/src/pages/MyTravelPage/MyTravelPage.tsx
@@ -42,13 +42,12 @@ export default function MyTravelPage() {
       <header className={classes.header}>
         <h1 className={classes.headerText}>내 여행 목록</h1>
         <Link
-          to="/login"
+          to="/setting"
           state={{ forward: true }}
           viewTransition
-          onClick={() => localStorage.removeItem('accessToken')}
           className={classes.logoutLink}
         >
-          로그아웃
+          개인 설정
         </Link>
       </header>
       {error ? error : ''}

--- a/src/pages/MyTravelPage/MyTravelPage.tsx
+++ b/src/pages/MyTravelPage/MyTravelPage.tsx
@@ -45,7 +45,7 @@ export default function MyTravelPage() {
           to="/setting"
           state={{ forward: true }}
           viewTransition
-          className={classes.logoutLink}
+          className={classes.menuLink}
         >
           개인 설정
         </Link>

--- a/src/pages/SettingPage/SettingPage.module.css
+++ b/src/pages/SettingPage/SettingPage.module.css
@@ -1,0 +1,71 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+}
+
+.header {
+  padding-top: 83px;
+  padding-inline: 38px;
+}
+
+.headerText {
+  margin-bottom: 0px;
+}
+
+.backButton {
+  border-radius: 10px;
+  padding: 0px;
+  border-style: none;
+  background-color: transparent;
+}
+
+.menuSection {
+  padding-inline: 38px;
+  margin-top: 16px;
+}
+
+.menuList {
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+  border-top: 1px solid #e8e8e8;
+}
+
+.menuList li {
+  margin: 0px;
+  padding: 0px;
+}
+
+.menuItem,
+.menuItemButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  border: none;
+  border-bottom: 1px solid #e8e8e8;
+  background: transparent;
+  padding: 16px 4px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #1f1f1f;
+  text-align: left;
+  text-decoration: none;
+}
+
+.menuItemButton {
+  cursor: pointer;
+  font: inherit;
+}
+
+.dangerMenuItem {
+  color: #e53935;
+}
+
+.chevronIcon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -15,7 +15,7 @@ export default function SettingPage() {
             navigate(-1);
           }}
         >
-          <img src={BlackBackIcon} alt="뒤로가기 버튼 이미지" />
+<img src={BlackBackIcon} alt="뒤로가기" />
         </button>
         <h1 className={classes.headerText}>개인 설정</h1>
       </header>

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -1,0 +1,81 @@
+import { Link, useNavigate } from 'react-router-dom';
+import BlackBackIcon from '@assets/icons/back-black.svg';
+import ChevronRightIcon from '@assets/icons/chevron-right.svg';
+import classes from './SettingPage.module.css';
+
+export default function SettingPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className={classes.container}>
+      <header className={classes.header}>
+        <button
+          className={classes.backButton}
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          <img src={BlackBackIcon} alt="뒤로가기 버튼 이미지" />
+        </button>
+        <h1 className={classes.headerText}>개인 설정</h1>
+      </header>
+      <main className={classes.menuSection}>
+        <ul className={classes.menuList}>
+          <li>
+            <Link
+              className={classes.menuItem}
+              to="/change-password"
+              state={{ forward: true }}
+              viewTransition
+            >
+              <span>비밀번호 변경</span>
+              <img
+                className={classes.chevronIcon}
+                src={ChevronRightIcon}
+                alt=""
+                aria-hidden="true"
+              />
+            </Link>
+          </li>
+          <li>
+            <button
+              className={classes.menuItemButton}
+              onClick={() => {
+                localStorage.removeItem('accessToken');
+                navigate('/login', {
+                  state: { forward: true },
+                  viewTransition: true,
+                });
+              }}
+              type="button"
+            >
+              <span>로그아웃</span>
+              <img
+                className={classes.chevronIcon}
+                src={ChevronRightIcon}
+                alt=""
+                aria-hidden="true"
+              />
+            </button>
+          </li>
+          <li>
+            <Link
+              className={`${classes.menuItem} ${classes.dangerMenuItem}`}
+              to="/delete-account"
+              state={{ forward: true }}
+              viewTransition
+            >
+              <span>회원탈퇴</span>
+              <img
+                className={classes.chevronIcon}
+                src={ChevronRightIcon}
+                alt=""
+                aria-hidden="true"
+              />
+            </Link>
+          </li>
+        </ul>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#79 의 회원탈퇴 페이지를 구현 하기전에 비밀번호 변경, 회원탈퇴 페이지로 이동할 수 있는 개인 설정페이지를 구현하였고 라우팅 설정까지 마쳤습니다. 추가로 내 여행목록페이지의 로그아웃 링크를 개인 설정 페이지로 이동할 수 있는 링크로 수정하였습니다.

### 스크린샷 또는 구동 연상(선택)


https://github.com/user-attachments/assets/6d4eb687-cd7c-46d5-9b17-6fb927e3c56a

