### PR TITLE
feat: 비밀번호 변경 및 회원 탈퇴 API 서비스 메소드 구현

### DIFF
--- a/src/apis/http.ts
+++ b/src/apis/http.ts
@@ -75,9 +75,10 @@ export const http = {
   delete: async <T>(
     url: string,
     token?: string,
+    body?: unknown,
     headers?: Record<string, string>
   ) => {
-    return request<T>('DELETE', url, token, headers);
+    return request<T>('DELETE', url, token, headers, body);
   },
   patch: async <T>(
     url: string,

--- a/src/apis/services/auth.ts
+++ b/src/apis/services/auth.ts
@@ -1,5 +1,10 @@
 import { http } from '../http';
-import type { SignUpInput, LoginInput, Token } from 'src/types/auth.type';
+import type {
+  SignUpInput,
+  LoginInput,
+  Token,
+  ChangePasswordInput,
+} from 'src/types/auth.type';
 
 export const authService = {
   signUp: (input: SignUpInput) => {
@@ -18,10 +23,7 @@ export const authService = {
       status?: number;
     }>('/api/auth/account', token, { password });
   },
-  changePassword: (
-    input: { password: string; new_password: string },
-    token: string
-  ) => {
+  changePassword: (input: ChangePasswordInput, token: string) => {
     return http.patch<{
       message: string;
       error?: string;

--- a/src/apis/services/auth.ts
+++ b/src/apis/services/auth.ts
@@ -11,4 +11,11 @@ export const authService = {
   logout: () => {
     return http.post<string>('/api/auth/login', undefined);
   },
+  deleteAccount: (password: string, token: string) => {
+    return http.delete<{
+      message: string;
+      error?: string;
+      status?: number;
+    }>('/api/auth/account', token, { password });
+  },
 };

--- a/src/apis/services/auth.ts
+++ b/src/apis/services/auth.ts
@@ -18,4 +18,14 @@ export const authService = {
       status?: number;
     }>('/api/auth/account', token, { password });
   },
+  changePassword: (
+    input: { password: string; new_password: string },
+    token: string
+  ) => {
+    return http.patch<{
+      message: string;
+      error?: string;
+      status?: number;
+    }>('/api/auth/password', input, token);
+  },
 };

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -10,7 +10,7 @@ export interface LoginInput {
   password: string;
 }
 
-export interface changePasswordInput {
+export interface ChangePasswordInput {
   password: string;
   new_password: string;
 }

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -10,6 +10,11 @@ export interface LoginInput {
   password: string;
 }
 
+export interface changePasswordInput {
+  password: string;
+  new_password: string;
+}
+
 export interface Token {
   token_type: string;
   access_token: string;


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

새롭게 추가된 비밀번호 변경 및 회원 탈퇴 API 서비스 메소드를 추가했습니다.
자체 테스트 결과 정상적으로 작동합니다.

`authService` 의 `deleteAccount` 와 `changePassword` 로 사용할 수 있습니다. 