### PR TITLE
feat: 회원탈퇴 페이지 구현

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -21,6 +21,8 @@ import SelectThumbnailPage from './pages/SelectThumbnailPage/SelectThumbnailPage
 import SelectThumbnailPhotoPage from './pages/SelectThumbnailPhotoPage/SelectThumbnailPhotoPage';
 import MapPage from './pages/MapPage/MapPage';
 import ErrorRoute from './pages/ErrorPage/ErrorRoute';
+import DeleteAccountPage from './pages/DeleteAccountPage/DeleteAccountPage';
+import DeleteAccountCompletePage from './pages/DeleteAccountCompletePage/DeleteAccountCompletePage';
 
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import { Transition } from './pages/Transition/Transition';
@@ -53,6 +55,14 @@ const router = createBrowserRouter([
           {
             path: '/my-travel',
             Component: MyTravelPage,
+          },
+          {
+            path: '/delete-account',
+            Component: DeleteAccountPage,
+          },
+          {
+            path: '/delete-account/complete',
+            Component: DeleteAccountCompletePage,
           },
           {
             path: '/map',

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -6,6 +6,8 @@ type OpenModalOptions = {
   message: string;
   confirmText?: string;
   cancelText?: string;
+  confirmVariant?: 'blue' | 'gray' | 'red';
+  cancelVariant?: 'blue' | 'gray' | 'red';
   onConfirm?: () => void;
   onCancel?: () => void;
 };
@@ -20,6 +22,8 @@ type ModalState = {
   message: string;
   confirmText: string;
   cancelText: string;
+  confirmVariant?: 'blue' | 'gray' | 'red';
+  cancelVariant?: 'blue' | 'gray' | 'red';
   onConfirm?: () => void;
   onCancel?: () => void;
 };
@@ -44,6 +48,8 @@ export default function useModal(initialOptions?: InitialModalOptions) {
       cancelText: initialOptions.cancelText ?? '취소',
       onConfirm: initialOptions.onConfirm,
       onCancel: initialOptions.onCancel,
+      confirmVariant: initialOptions.confirmVariant ?? 'blue',
+      cancelVariant: initialOptions.cancelVariant ?? 'gray',
     };
   });
 
@@ -60,6 +66,8 @@ export default function useModal(initialOptions?: InitialModalOptions) {
       cancelText: options.cancelText ?? '취소',
       onConfirm: options.onConfirm,
       onCancel: options.onCancel,
+      cancelVariant: options.cancelVariant ?? 'gray',
+      confirmVariant: options.confirmVariant ?? 'blue',
     });
   }, []);
 
@@ -78,10 +86,10 @@ export default function useModal(initialOptions?: InitialModalOptions) {
       <Modal.Title>{state.title}</Modal.Title>
       <p>{state.message}</p>
       <Modal.ButtonGroup>
-        <Modal.Button variant="gray" onClick={handleCancel}>
+        <Modal.Button variant={state.cancelVariant} onClick={handleCancel}>
           {state.cancelText}
         </Modal.Button>
-        <Modal.Button variant="blue" onClick={handleConfirm}>
+        <Modal.Button variant={state.confirmVariant} onClick={handleConfirm}>
           {state.confirmText}
         </Modal.Button>
       </Modal.ButtonGroup>

--- a/src/pages/DeleteAccountCompletePage/DeleteAccountCompletePage.module.css
+++ b/src/pages/DeleteAccountCompletePage/DeleteAccountCompletePage.module.css
@@ -1,0 +1,35 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 38px;
+}
+
+.content {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+}
+
+.title {
+  margin: 0px;
+}
+
+.description {
+  margin: 0px;
+  color: #666666;
+}
+
+.loginButton {
+  margin-top: 12px;
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background-color: #0d9eff;
+  color: #ffffff;
+  font-size: 16px;
+  padding: 14px 16px;
+}

--- a/src/pages/DeleteAccountCompletePage/DeleteAccountCompletePage.tsx
+++ b/src/pages/DeleteAccountCompletePage/DeleteAccountCompletePage.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from 'react-router-dom';
+import classes from './DeleteAccountCompletePage.module.css';
+
+export default function DeleteAccountCompletePage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className={classes.container}>
+      <main className={classes.content}>
+        <h1 className={classes.title}>회원탈퇴 완료</h1>
+        <p className={classes.description}>
+          그동안 여기닷을 이용해주셔서 감사합니다.
+        </p>
+        <button
+          className={classes.loginButton}
+          onClick={() => {
+            localStorage.removeItem('accessToken');
+            navigate('/login', {
+              viewTransition: true,
+              state: { forward: true },
+            });
+          }}
+        >
+          로그인 화면으로 이동
+        </button>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/DeleteAccountPage/DeleteAccountPage.module.css
+++ b/src/pages/DeleteAccountPage/DeleteAccountPage.module.css
@@ -1,0 +1,117 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  row-gap: 20px;
+  min-height: 100dvh;
+}
+
+.header {
+  padding-top: 83px;
+  padding-inline: 38px;
+}
+
+.headerText {
+  margin-bottom: 0px;
+}
+
+.backButton {
+  border-radius: 10px;
+  padding: 0px;
+  border-style: none;
+  background-color: transparent;
+}
+
+.content {
+  padding-inline: 38px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+  flex: 1;
+}
+
+.pageTitle {
+  margin: 0;
+  font-size: 24px;
+}
+
+.warningText {
+  color: #666666;
+  line-height: 24px;
+  margin: 0;
+}
+
+.deletedDataList {
+  margin: 0;
+  padding-left: 22px;
+  color: #444444;
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+  line-height: 24px;
+}
+
+.inputSection {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+}
+
+.inputHeader {
+  margin: 0;
+}
+
+.textInput {
+  margin: 0 auto;
+  width: 90%;
+  height: 44px;
+  border-radius: 5px;
+  border-style: none;
+  font-size: 20px;
+  border-width: 1px;
+  background-color: #f5f5f5;
+  padding-inline: 5%;
+}
+
+.textInputError {
+  border-style: solid;
+  border-color: red;
+}
+
+.textInputError:focus {
+  outline-color: red;
+}
+
+.textInput:focus {
+  outline-color: #0d9eff;
+  outline-offset: 0px;
+}
+
+.errorHelperText {
+  color: red;
+  font-size: 14px;
+  margin: 0;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.deleteButton {
+  width: 100%;
+  border-radius: 10px;
+  background-color: #e53935;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  padding: 14px 16px;
+  height: auto;
+  min-width: 0;
+  margin-top: auto;
+  margin-bottom: 24px;
+}
+
+.modalMessage {
+  margin: 0;
+  color: #555555;
+  line-height: 22px;
+}

--- a/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
@@ -1,0 +1,112 @@
+import BlackBackIcon from '@assets/icons/back-black.svg';
+import Button from '@components/Buttons/Button/Button';
+import Modal from '@components/Modal/Modal';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import classes from './DeleteAccountPage.module.css';
+
+export default function DeleteAccountPage() {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [passwordErrorText, setPasswordErrorText] = useState('');
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+
+  const handlePasswordInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (event.target.value !== '') {
+      setPasswordErrorText('');
+    }
+    setPassword(event.target.value);
+  };
+
+  const handleDeleteButtonClick = () => {
+    if (password.trim() === '') {
+      setPasswordErrorText('비밀번호를 입력해주세요.');
+      return;
+    }
+    setIsConfirmModalOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    setIsConfirmModalOpen(false);
+    navigate('/delete-account/complete', {
+      viewTransition: true,
+      state: { forward: true },
+    });
+  };
+
+  return (
+    <div className={classes.container}>
+      <header className={classes.header}>
+        <button
+          className={classes.backButton}
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          <img src={BlackBackIcon} alt="뒤로가기 버튼 이미지" />
+        </button>
+        <h1 className={classes.headerText}>회원탈퇴</h1>
+      </header>
+      <main className={classes.content}>
+        <h2 className={classes.pageTitle}>여기닷 앱 회원 탈퇴</h2>
+        <p className={classes.warningText}>
+          회원탈퇴 시 아래 데이터가 모두 삭제되며 복구할 수 없습니다.
+        </p>
+        <ul className={classes.deletedDataList}>
+          <li>사용자 이메일</li>
+          <li>업로드한 사진</li>
+          <li>여행 데이터 (여행 정보, 코멘트, 여행일기 등)</li>
+          <li>그 외 사용자와 관련된 모든 데이터</li>
+        </ul>
+        <section className={classes.inputSection}>
+          <h3 className={classes.inputHeader}>비밀번호 확인</h3>
+          <input
+            className={`${classes.textInput} ${passwordErrorText !== '' ? classes.textInputError : ''}`}
+            onChange={handlePasswordInputChange}
+            value={password}
+            type="password"
+            id="delete-account-password"
+            autoComplete="off"
+          />
+          <p
+            className={`${classes.errorHelperText} ${passwordErrorText === '' ? classes.invisible : ''}`}
+          >
+            {passwordErrorText === '' ? '오류 없음' : passwordErrorText}
+          </p>
+        </section>
+        <Button
+          className={classes.deleteButton}
+          onClick={handleDeleteButtonClick}
+        >
+          탈퇴 진행하기
+        </Button>
+      </main>
+      <Modal.Root
+        isOpen={isConfirmModalOpen}
+        onCancel={() => {
+          setIsConfirmModalOpen(false);
+        }}
+      >
+        <Modal.Title>정말로 탈퇴하겠습니까?</Modal.Title>
+        <p className={classes.modalMessage}>
+          확인을 누르면 회원 탈퇴가 완료되고 데이터는 복구할 수 없습니다.
+        </p>
+        <Modal.ButtonGroup>
+          <Modal.Button
+            variant="gray"
+            onClick={() => {
+              setIsConfirmModalOpen(false);
+            }}
+          >
+            취소
+          </Modal.Button>
+          <Modal.Button variant="red" onClick={handleConfirmDelete}>
+            확인
+          </Modal.Button>
+        </Modal.ButtonGroup>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
@@ -38,6 +38,7 @@ export default function DeleteAccountPage() {
       message:
         '확인을 누르면 회원 탈퇴가 완료되고 데이터는 복구할 수 없습니다.',
       onConfirm: handleConfirmDelete,
+      confirmVariant: 'red',
     });
   };
 

--- a/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
+++ b/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
@@ -1,16 +1,24 @@
 import BlackBackIcon from '@assets/icons/back-black.svg';
 import Button from '@components/Buttons/Button/Button';
-import Modal from '@components/Modal/Modal';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import classes from './DeleteAccountPage.module.css';
+import { useApi } from '@hooks/api';
+import { authService } from 'src/apis/services/auth';
+import useModal from '@hooks/useModal';
+
+const DELETE_ACCOUNT_ERROR_MESSAGES: Record<number, string> = {
+  400: '비밀번호가 일치하지 않습니다.',
+  401: '인증이 필요합니다.',
+};
 
 export default function DeleteAccountPage() {
   const navigate = useNavigate();
+  const { openModal, modalElement } = useModal();
   const [password, setPassword] = useState('');
   const [passwordErrorText, setPasswordErrorText] = useState('');
-  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-
+  const { status, request } = useApi(authService.deleteAccount);
+  const token = localStorage.getItem('accessToken');
   const handlePasswordInputChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -25,16 +33,44 @@ export default function DeleteAccountPage() {
       setPasswordErrorText('비밀번호를 입력해주세요.');
       return;
     }
-    setIsConfirmModalOpen(true);
-  };
-
-  const handleConfirmDelete = () => {
-    setIsConfirmModalOpen(false);
-    navigate('/delete-account/complete', {
-      viewTransition: true,
-      state: { forward: true },
+    openModal({
+      title: '정말로 탈퇴하겠습니까?',
+      message:
+        '확인을 누르면 회원 탈퇴가 완료되고 데이터는 복구할 수 없습니다.',
+      onConfirm: handleConfirmDelete,
     });
   };
+
+  const handleConfirmDelete = async () => {
+    if (!token) {
+      openModal({
+        title: '회원탈퇴 실패',
+        message: DELETE_ACCOUNT_ERROR_MESSAGES[401],
+      });
+      return;
+    }
+    await request(password, token);
+  };
+
+  useEffect(() => {
+    if (status === null) {
+      return;
+    }
+    if (status === 200) {
+      navigate('/delete-account/complete', {
+        viewTransition: true,
+        state: { forward: true },
+      });
+      return;
+    }
+
+    openModal({
+      title: '회원탈퇴 실패',
+      message:
+        DELETE_ACCOUNT_ERROR_MESSAGES[status] ??
+        '회원탈퇴 중 오류가 발생했습니다.',
+    });
+  }, [navigate, openModal, status]);
 
   return (
     <div className={classes.container}>
@@ -83,30 +119,7 @@ export default function DeleteAccountPage() {
           탈퇴 진행하기
         </Button>
       </main>
-      <Modal.Root
-        isOpen={isConfirmModalOpen}
-        onCancel={() => {
-          setIsConfirmModalOpen(false);
-        }}
-      >
-        <Modal.Title>정말로 탈퇴하겠습니까?</Modal.Title>
-        <p className={classes.modalMessage}>
-          확인을 누르면 회원 탈퇴가 완료되고 데이터는 복구할 수 없습니다.
-        </p>
-        <Modal.ButtonGroup>
-          <Modal.Button
-            variant="gray"
-            onClick={() => {
-              setIsConfirmModalOpen(false);
-            }}
-          >
-            취소
-          </Modal.Button>
-          <Modal.Button variant="red" onClick={handleConfirmDelete}>
-            확인
-          </Modal.Button>
-        </Modal.ButtonGroup>
-      </Modal.Root>
+      {modalElement}
     </div>
   );
 }


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

구글 플레이 앱 설정을 위한 회원탈퇴 구현 페이지를 구현하였습니다.
#79 의 사진에 명시된 내용을 적용하였고 비밀번호 오류 및 권한 오류 시 모달이 열리게, 성공 시 회원탈퇴 확인 페이지로 이동되게 구현했습니다.
그 과정에서 탈퇴 확인을 받는 모달에서 확인에 `red` variant를 적용하기 위해 기존 훅을 수정했습니다.

### 스크린샷 또는 구동 연상(선택)

https://github.com/user-attachments/assets/eb0d8afc-db74-4f84-bbaa-f1eca0f0a319

