### PR TITLE
Feature/travel and daytravel UI

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -23,6 +23,7 @@ import MapPage from './pages/MapPage/MapPage';
 import ErrorRoute from './pages/ErrorPage/ErrorRoute';
 import DeleteAccountPage from './pages/DeleteAccountPage/DeleteAccountPage';
 import DeleteAccountCompletePage from './pages/DeleteAccountCompletePage/DeleteAccountCompletePage';
+import ChangePasswordPage from './pages/ChangePasswordPage/ChangePasswordPage';
 
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import { Transition } from './pages/Transition/Transition';
@@ -56,6 +57,10 @@ const router = createBrowserRouter([
           {
             path: '/my-travel',
             Component: MyTravelPage,
+          },
+          {
+            path: '/change-password',
+            Component: ChangePasswordPage,
           },
           {
             path: '/delete-account',

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
@@ -1,0 +1,65 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+}
+
+.header {
+  padding-top: 83px;
+  padding-inline: 38px;
+}
+
+.signUpForm {
+  position: relative;
+  padding-inline: 38px;
+}
+
+
+.passwordForm,
+.newPasswordForm,
+.passwordCheckForm {
+  position: relative;
+  margin-top: 20px;
+  /* 위쪽 간격 */
+  margin-bottom: 30px;
+  /* 아래쪽 간격 (에러 메시지 공간 확보) */
+}
+
+
+.passwordInput,
+.newPasswordInput,
+.passwordCheckInput {
+  margin-top: 5px;
+  width: 100%;
+  height: 49px;
+  border-radius: 5px;
+  border-color: #A9A9A9;
+  border-style: solid;
+  box-sizing: border-box;
+  /* 패딩 포함 크기 계산 */
+}
+
+.signUpButton {
+  display: block;
+  margin: 310px auto;
+  width: 108px;
+  height: 55px;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.errorMessage {
+  position: absolute;
+  /* 자리를 차지하지 않고 공중에 뜸 -> 레이아웃 밀림 방지 */
+  left: 0;
+  top: 100%;
+  /* input의 바로 밑바닥 */
+  margin-top: 6px;
+  /* input과 살짝 띄우기 */
+
+  font-size: 15px;
+  color: #e53935;
+  line-height: 1.2;
+  white-space: nowrap;
+  /* 줄바꿈 방지 */
+}

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
@@ -9,7 +9,7 @@
   padding-inline: 38px;
 }
 
-.signUpForm {
+.changePasswordForm {
   position: relative;
   padding-inline: 38px;
 }

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.module.css
@@ -39,7 +39,7 @@
   /* 패딩 포함 크기 계산 */
 }
 
-.signUpButton {
+.submitButton {
   display: block;
   margin: 310px auto;
   width: 108px;

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
@@ -51,6 +51,7 @@ export default function ChangePasswordPage() {
         title: '비밀번호 변경 완료',
         message: '비밀번호가 성공적으로 변경되었습니다!',
         onConfirm: () => navigate(-1),
+        onCancel: () => navigate(-1),
       });
     } catch (error: any) {
       console.error('비밀번호 변경 에러:', error);

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
@@ -89,7 +89,7 @@ export default function ChangePasswordPage() {
         <h1 className={classes.headerText}>비밀번호 변경</h1>
       </header>
 
-      <form onSubmit={handleSubmit(onSubmit)} className={classes.signUpForm}>
+      <form onSubmit={handleSubmit(onSubmit)} className={classes.changePasswordForm}>
         {/* 현재 비밀번호 */}
         <div className={classes.passwordForm}>
           <h3>현재 비밀번호</h3>

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
@@ -1,0 +1,143 @@
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+import BackButton from '@components/Buttons/BackButton/BlackBackButton/BlackBackButton';
+import Button from '@components/Buttons/Button/Button';
+import classes from './ChangePasswordPage.module.css';
+import { ChangePasswordSchema } from './ChangePasswordSchema';
+import useModal from '@hooks/useModal';
+import type { ChangePasswordInput } from '../../types/auth.type';
+import { authService } from '../../apis/services/auth';
+
+type ChangePasswordForm = z.infer<typeof ChangePasswordSchema>;
+
+export default function ChangePasswordPage() {
+  const navigate = useNavigate();
+  const { openModal, modalElement } = useModal();
+
+  const token = localStorage.getItem('accessToken');
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<ChangePasswordForm>({
+    resolver: zodResolver(ChangePasswordSchema),
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (data: ChangePasswordForm) => {
+    try {
+      if (!token) {
+        openModal({
+          title: '비밀번호 변경 실패',
+          message: '로그인이 필요합니다.',
+          onConfirm: () => navigate('/login'),
+        });
+        return;
+      }
+
+      const input: ChangePasswordInput = {
+        password: data.password,
+        new_password: data.new_password,
+      };
+
+      await authService.changePassword(input, token);
+
+      // 성공 시 처리
+      openModal({
+        title: '비밀번호 변경 완료',
+        message: '비밀번호가 성공적으로 변경되었습니다!',
+        onConfirm: () => navigate(-1),
+      });
+    } catch (error: any) {
+      console.error('비밀번호 변경 에러:', error);
+
+      const status = error.status;
+
+      if (status === 400) {
+        setError('password', { message: '현재 비밀번호가 일치하지 않습니다.' });
+      } else if (status === 401) {
+        openModal({
+          title: '인증 만료',
+          message: '인증이 만료되었습니다. 다시 로그인해주세요.',
+          onConfirm: () => navigate('/login'),
+        });
+      } else {
+        const errorMsg = error.message || '알 수 없는 에러';
+        const statusCode = status || '';
+        openModal({
+          title: '비밀번호 변경 실패',
+          message: `비밀번호 변경 실패 (${statusCode})\n${errorMsg}`,
+        });
+      }
+    }
+  };
+
+  return (
+    <div className={classes.container}>
+      <header className={classes.header}>
+        <BackButton
+          onClick={() => {
+            navigate(-1);
+          }}
+        />
+        <h1 className={classes.headerText}>비밀번호 변경</h1>
+      </header>
+
+      <form onSubmit={handleSubmit(onSubmit)} className={classes.signUpForm}>
+        {/* 현재 비밀번호 */}
+        <div className={classes.passwordForm}>
+          <h3>현재 비밀번호</h3>
+          <input
+            {...register('password')}
+            type="password"
+            className={classes.passwordInput}
+          />
+          {errors.password && (
+            <span className={classes.errorMessage}>
+              {errors.password.message}
+            </span>
+          )}
+        </div>
+
+        {/* 새 비밀번호 */}
+        <div className={classes.newPasswordForm}>
+          <h3>새 비밀번호</h3>
+          <input
+            {...register('new_password')}
+            type="password"
+            className={classes.newPasswordInput}
+          />
+          {errors.new_password && (
+            <span className={classes.errorMessage}>
+              {errors.new_password.message}
+            </span>
+          )}
+        </div>
+
+        {/* 새 비밀번호 확인 */}
+        <div className={classes.passwordCheckForm}>
+          <h3>새 비밀번호 확인</h3>
+          <input
+            {...register('new_password_check')}
+            type="password"
+            className={classes.passwordCheckInput}
+          />
+          {errors.new_password_check && (
+            <span className={classes.errorMessage}>
+              {errors.new_password_check.message}
+            </span>
+          )}
+        </div>
+
+        <Button type="submit" className={classes.signUpButton}>
+          변경
+        </Button>
+      </form>
+      {modalElement}
+    </div>
+  );
+}

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
@@ -135,7 +135,7 @@ export default function ChangePasswordPage() {
           )}
         </div>
 
-        <Button type="submit" className={classes.signUpButton}>
+        <Button type="submit" className={classes.submitButton}>
           변경
         </Button>
       </form>

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.tsx
@@ -64,6 +64,7 @@ export default function ChangePasswordPage() {
           title: '인증 만료',
           message: '인증이 만료되었습니다. 다시 로그인해주세요.',
           onConfirm: () => navigate('/login'),
+          onCancel: () => navigate('/login'),
         });
       } else {
         const errorMsg = error.message || '알 수 없는 에러';

--- a/src/pages/ChangePasswordPage/ChangePasswordSchema.ts
+++ b/src/pages/ChangePasswordPage/ChangePasswordSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const ChangePasswordSchema = z.object({
+  password: z
+    .string()
+    .min(8, '비밀번호는 8자 이상이어야 합니다')
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)/, '영문과 숫자를 포함해야 합니다'),
+
+  new_password: z
+    .string()
+    .min(8, '비밀번호는 8자 이상이어야 합니다')
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)/, '영문과 숫자를 포함해야 합니다'),
+
+  new_password_check: z.string(),
+
+}).refine(
+  data => data.new_password === data.new_password_check,
+  {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['new_password_check']
+  }
+);


### PR DESCRIPTION
## 작업 내용

개인설정 페이지에 비밀번호 변경 기능 페이지를 구현하였습니다.

### 스크린샷 또는 구동 연상(선택)
<img width="408" height="913" alt="image" src="https://github.com/user-attachments/assets/3cf51a33-7b57-4f1a-bc8e-d80be4cc7c48" />
<img width="410" height="910" alt="image" src="https://github.com/user-attachments/assets/bb7a79bc-6c1e-4c3f-81fd-6233a042e5fc" />
기본적인 유효성 검사를 실행합니다.
<img width="411" height="911" alt="image" src="https://github.com/user-attachments/assets/227419f9-2659-4697-b7eb-45e1c5eac542" />
새로운 비밀번호 일치여부을 출력합니다.
<img width="408" height="911" alt="image" src="https://github.com/user-attachments/assets/8a71bf32-cd48-4348-893b-0a7f0505b98f" />
비밀번호 변경 성공시 메시지를 출력하고 개인설정 페이지로 돌아갑니다.
