### PR TITLE
fix: 줌 스크롤 오류 해결

### DIFF
--- a/src/components/FullPhotoLayout/FullPhotoLayout.tsx
+++ b/src/components/FullPhotoLayout/FullPhotoLayout.tsx
@@ -27,6 +27,7 @@ export default function FullPhotoLayout({
   }>({ eventCache: [], previousDiff: null });
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const imageWidthPercentRef = useRef(imageWidthDefaultPercent);
   const [imageWidthPercent, setImageWidthPercent] = useState(
     imageWidthDefaultPercent
   );
@@ -46,38 +47,28 @@ export default function FullPhotoLayout({
       );
       const nowDiff = getDiff(nextEventCache);
       const center = getCenter(nextEventCache);
+
+      const prevWidth = imageWidthPercentRef.current;
+      let nextWidth = prevWidth;
+
       if (
         detectZoom(previousDiff, nowDiff) === 'ZOOM IN' &&
         imageWidthPercent < MAX_WIDTH_PERCENT
       ) {
-        setImageWidthPercent(widthPercent =>
-          widthPercent * 1.01 < MAX_WIDTH_PERCENT
-            ? widthPercent * 1.01
-            : widthPercent
-        );
-        scrollToScailedCenter(
-          center,
-          containerRef.current,
-          imageWidthPercent * 0.01,
-          window.innerHeight
-        );
+        nextWidth = Math.min(prevWidth * 1.01, MAX_WIDTH_PERCENT);
       }
       if (
         detectZoom(previousDiff, nowDiff) === 'ZOOM OUT' &&
         imageWidthPercent > MIN_WIDTH_PERCENT
       ) {
-        setImageWidthPercent(widthPercent =>
-          widthPercent * 0.99 > MIN_WIDTH_PERCENT
-            ? widthPercent * 0.99
-            : widthPercent
-        );
-        scrollToScailedCenter(
-          center,
-          containerRef.current,
-          imageWidthPercent * 0.01,
-          window.innerHeight
-        );
+        nextWidth = Math.max(prevWidth * 0.99, MIN_WIDTH_PERCENT);
       }
+
+      setImageWidthPercent(nextWidth);
+      imageWidthPercentRef.current = nextWidth;
+      const scale = nextWidth / prevWidth;
+      scrollToScailedCenter(center, containerRef.current, scale);
+
       return {
         eventCache: nextEventCache,
         previousDiff: nowDiff ? nowDiff : previousDiff,

--- a/src/components/FullPhotoLayout/FullPhotoLayout.tsx
+++ b/src/components/FullPhotoLayout/FullPhotoLayout.tsx
@@ -1,12 +1,15 @@
-import { useRef, useState, type ReactElement } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import type { DatedPhotoData } from 'src/types/photo.type';
 import classes from './FullPhotoLayout.module.css';
 import { getCenter, getDiff, detectZoom } from '@utils/zoom';
 interface Props {
   photo: DatedPhotoData;
-  children?: ReactElement[] | ReactElement;
+  children?: ReactNode;
   imageWidthDefaultPercent?: number;
 }
+
+const MAX_WIDTH_PERCENT = 300;
+const MIN_WIDTH_PERCENT = 100;
 
 export default function FullPhotoLayout({
   photo,
@@ -55,10 +58,12 @@ export default function FullPhotoLayout({
       const center = getCenter(nextEventCache);
       if (
         detectZoom(previousDiff, nowDiff) === 'ZOOM IN' &&
-        imageWidthPercent < 300
+        imageWidthPercent < MAX_WIDTH_PERCENT
       ) {
         setImageWidthPercent(widthPercent =>
-          widthPercent < 300 ? widthPercent * 1.01 : 300
+          widthPercent * 1.01 < MAX_WIDTH_PERCENT
+            ? widthPercent * 1.01
+            : widthPercent
         );
         scrollToScailedCenter(
           center,
@@ -69,10 +74,12 @@ export default function FullPhotoLayout({
       }
       if (
         detectZoom(previousDiff, nowDiff) === 'ZOOM OUT' &&
-        imageWidthPercent > 100
+        imageWidthPercent > MIN_WIDTH_PERCENT
       ) {
         setImageWidthPercent(widthPercent =>
-          widthPercent > 100 ? widthPercent * 0.99 : 100
+          widthPercent * 0.99 > MIN_WIDTH_PERCENT
+            ? widthPercent * 0.99
+            : widthPercent
         );
         scrollToScailedCenter(
           center,

--- a/src/components/FullPhotoLayout/FullPhotoLayout.tsx
+++ b/src/components/FullPhotoLayout/FullPhotoLayout.tsx
@@ -1,7 +1,12 @@
 import { useRef, useState, type ReactNode } from 'react';
 import type { DatedPhotoData } from 'src/types/photo.type';
 import classes from './FullPhotoLayout.module.css';
-import { getCenter, getDiff, detectZoom } from '@utils/zoom';
+import {
+  getCenter,
+  getDiff,
+  detectZoom,
+  scrollToScailedCenter,
+} from '@utils/zoom';
 interface Props {
   photo: DatedPhotoData;
   children?: ReactNode;
@@ -25,21 +30,6 @@ export default function FullPhotoLayout({
   const [imageWidthPercent, setImageWidthPercent] = useState(
     imageWidthDefaultPercent
   );
-
-  const scrollToScailedCenter = (
-    center: { x: number; y: number } | null,
-    container: HTMLDivElement | null,
-    ratio: number,
-    viewportHeight: number
-  ) => {
-    if (center === null || container === null) {
-      return;
-    }
-    const { x, y } = center;
-    const scaledX = x * ratio;
-    const scaledY = y * ratio;
-    container.scrollTo(scaledX - x, scaledY - (viewportHeight - y));
-  };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLImageElement>) => {
     setPointerStatus(({ eventCache, previousDiff }) => {

--- a/src/components/FullPhotoLayout/FullPhotoLayout.tsx
+++ b/src/components/FullPhotoLayout/FullPhotoLayout.tsx
@@ -5,7 +5,7 @@ import {
   getCenter,
   getDiff,
   detectZoom,
-  scrollToScailedCenter,
+  scrollToScaledCenter,
 } from '@utils/zoom';
 interface Props {
   photo: DatedPhotoData;
@@ -67,7 +67,7 @@ export default function FullPhotoLayout({
       setImageWidthPercent(nextWidth);
       imageWidthPercentRef.current = nextWidth;
       const scale = nextWidth / prevWidth;
-      scrollToScailedCenter(center, containerRef.current, scale);
+      scrollToScaledCenter(center, containerRef.current, scale);
 
       return {
         eventCache: nextEventCache,

--- a/src/components/FullPhotoLayout/FullPhotoLayout.tsx
+++ b/src/components/FullPhotoLayout/FullPhotoLayout.tsx
@@ -26,20 +26,19 @@ export default function FullPhotoLayout({
   const scrollToScailedCenter = (
     center: { x: number; y: number } | null,
     container: HTMLDivElement | null,
-    scailingRatio: number,
+    ratio: number,
     viewportHeight: number
   ) => {
     if (center === null || container === null) {
       return;
     }
     const { x, y } = center;
-    const scailedX = x * scailingRatio;
-    const scailedY = y * scailingRatio;
-    container.scrollTo(scailedX - x, scailedY - (viewportHeight - y));
+    const scaledX = x * ratio;
+    const scaledY = y * ratio;
+    container.scrollTo(scaledX - x, scaledY - (viewportHeight - y));
   };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLImageElement>) => {
-    console.log(event);
     setPointerStatus(({ eventCache, previousDiff }) => {
       return {
         eventCache: eventCache.length < 2 ? [...eventCache, event] : eventCache,
@@ -89,7 +88,6 @@ export default function FullPhotoLayout({
     });
   };
   const handlePointerCancel = (event: React.PointerEvent<HTMLImageElement>) => {
-    console.log(event);
     setPointerStatus(({ eventCache, previousDiff }) => {
       return {
         eventCache: eventCache.filter(

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -39,14 +39,18 @@ export const getCenter = (eventCache: React.PointerEvent[]) => {
 export const scrollToScailedCenter = (
   center: { x: number; y: number } | null,
   container: HTMLDivElement | null,
-  ratio: number,
-  viewportHeight: number
+  scale: number
 ) => {
-  if (center === null || container === null) {
+  if (center === null || container === null || scale === 1) {
     return;
   }
+
   const { x, y } = center;
-  const scaledX = x * ratio;
-  const scaledY = y * ratio;
-  container.scrollTo(scaledX - x, scaledY - (viewportHeight - y));
+
+  const contentX = container.scrollLeft + x;
+  const contentY = container.scrollTop + y;
+
+  const newScrollLeft = contentX * scale - x;
+  const newScrollTop = contentY * scale - y;
+  container.scrollTo(newScrollLeft, newScrollTop);
 };

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -35,3 +35,18 @@ export const getCenter = (eventCache: React.PointerEvent[]) => {
     y: (a.clientY + b.clientY) / 2,
   };
 };
+
+export const scrollToScailedCenter = (
+  center: { x: number; y: number } | null,
+  container: HTMLDivElement | null,
+  ratio: number,
+  viewportHeight: number
+) => {
+  if (center === null || container === null) {
+    return;
+  }
+  const { x, y } = center;
+  const scaledX = x * ratio;
+  const scaledY = y * ratio;
+  container.scrollTo(scaledX - x, scaledY - (viewportHeight - y));
+};

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -36,7 +36,7 @@ export const getCenter = (eventCache: React.PointerEvent[]) => {
   };
 };
 
-export const scrollToScailedCenter = (
+export const scrollToScaledCenter = (
   center: { x: number; y: number } | null,
   container: HTMLDivElement | null,
   scale: number


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

#37 에서 이야기 했었던 전체 사진 페이지 줌 로직을 수정했습니다. 줌을 진행할 때 이전화면 크기와, 현재 크기의 비율이 올바르게 계산되지 않았고, 스크롤 시 원래 사진 크기가 화면 크기로 잘려서 계산되는 버그를 수정하여 해결하였습니다.

### 스크린샷 또는 구동 연상(선택)


https://github.com/user-attachments/assets/9f12c4f9-ac13-4847-9d12-b8223247604f



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
