### PR TITLE
fix: safari 환경에서 webp 변환 작동하도록 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@jsquash/webp": "^1.5.0",
         "exifreader": "^4.33.1",
         "leaflet": "^1.9.4",
         "react": "^19.1.1",
@@ -1688,6 +1689,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsquash/webp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsquash/webp/-/webp-1.5.0.tgz",
+      "integrity": "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5332,6 +5342,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@jsquash/webp": "^1.5.0",
     "exifreader": "^4.33.1",
     "leaflet": "^1.9.4",
     "react": "^19.1.1",

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -32,7 +32,8 @@ export async function photoFileToWebp(photoFile: File) {
         const webpArrayBuffer = await encode(photoImageData);
         const webpFile = new File(
           [webpArrayBuffer],
-          photoFile.name.replace(/(\.[^/.]+)?$/, '.webp')
+          photoFile.name.replace(/(\.[^/.]+)?$/, '.webp'),
+          { type: 'image/webp' }
         );
         resolve(webpFile);
       } catch {

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -1,3 +1,5 @@
+import { encode } from '@jsquash/webp';
+
 export async function photoFileToWebp(photoFile: File) {
   return new Promise<File>((resolve, reject) => {
     const imageURL = URL.createObjectURL(photoFile);
@@ -8,7 +10,7 @@ export async function photoFileToWebp(photoFile: File) {
       );
       URL.revokeObjectURL(imageURL);
     };
-    image.onload = () => {
+    image.onload = async () => {
       const canvas = document.createElement('canvas');
       canvas.width = image.width;
       canvas.height = image.height;
@@ -19,21 +21,25 @@ export async function photoFileToWebp(photoFile: File) {
         );
         return;
       }
-      context?.drawImage(image, 0, 0);
-      canvas.toBlob(
-        blob => {
-          if (blob) {
-            resolve(
-              new File([blob], photoFile.name.replace(/(\.[^/.]+)?$/, '.webp'))
-            );
-          } else {
-            reject(new Error('이미지 변환 실패'));
-          }
-        },
-        'image/webp',
-        0.7
-      );
-      URL.revokeObjectURL(imageURL);
+      context.drawImage(image, 0, 0);
+      try {
+        const photoImageData = context.getImageData(
+          0,
+          0,
+          image.width,
+          image.height
+        );
+        const webpArrayBuffer = await encode(photoImageData);
+        const webpFile = new File(
+          [webpArrayBuffer],
+          photoFile.name.replace(/(\.[^/.]+)?$/, '.webp')
+        );
+        resolve(webpFile);
+      } catch {
+        reject(new Error('이미지 변환 실패'));
+      } finally {
+        URL.revokeObjectURL(imageURL);
+      }
     };
     image.src = imageURL;
   });

--- a/src/utils/photo.ts
+++ b/src/utils/photo.ts
@@ -35,7 +35,8 @@ export async function photoFileToWebp(photoFile: File) {
           photoFile.name.replace(/(\.[^/.]+)?$/, '.webp')
         );
         resolve(webpFile);
-      } catch {
+      } catch (error) {
+        console.error('WebP 변환 중 오류 발생:', error);
         reject(new Error('이미지 변환 실패'));
       } finally {
         URL.revokeObjectURL(imageURL);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
-import { cloudflare } from "@cloudflare/vite-plugin";
+import { cloudflare } from '@cloudflare/vite-plugin';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), svgr(), cloudflare()],
+  optimizeDeps: {
+    exclude: ['@jsquash/webp'],
+  },
 });


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

ios 앱 테스트 중, safari 브라우저에서는 `canvas`의 `.toBlob()` 메소드 `image/webp` 옵션을 지원하지 않아 
webp 변환이 정상적으로 진행되지 않는 문제를 발견하여, safari 브라우저에서도 사용할 수 있는 변환 라이브러리를 활용하여 수정했습니다. 

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility
