### PR TITLE
fix: 사진 날짜 및 업로드 로직 수정

### DIFF
--- a/src/apis/services/travel.ts
+++ b/src/apis/services/travel.ts
@@ -57,9 +57,7 @@ export const travelService = {
       photo => photo.id === travel.thumbnailPhotoId
     );
     const uploadedRepresentativePhoto = uploadedData.data.uploadedPhotos.find(
-      photo =>
-        photo.takenAt === localRepresentativePhoto?.date &&
-        photo.originalName === localRepresentativePhoto?.file.name
+      photo => photo.originalName === localRepresentativePhoto?.file.name
     );
 
     if (uploadedRepresentativePhoto === undefined) {

--- a/src/components/Modal/DatetimeModal/DatetimeModal.tsx
+++ b/src/components/Modal/DatetimeModal/DatetimeModal.tsx
@@ -13,6 +13,9 @@ export default function DatetimeModal({
 }: Props) {
   const timezoneOffset = new Date().getTimezoneOffset() * 60000;
   const [date, setDate] = useState(currentDate);
+  const nowDate = new Date(Date.now() - timezoneOffset)
+    .toISOString()
+    .slice(0, 16);
   const handleDatetimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDate(event.currentTarget.value);
   };
@@ -38,13 +41,7 @@ export default function DatetimeModal({
             className={classes.datetimePicker}
             id="datetime-picker"
             type="datetime-local"
-            defaultValue={
-              currentDate
-                ? currentDate.slice(0, 16)
-                : new Date(Date.now() - timezoneOffset)
-                    .toISOString()
-                    .slice(0, 16)
-            }
+            defaultValue={currentDate ? currentDate.slice(0, 16) : nowDate}
             onChange={handleDatetimeChange}
           />
         </div>
@@ -62,8 +59,9 @@ export default function DatetimeModal({
             className={classes.confirmButton}
             onClick={() => {
               if (onConfirm) {
-                onConfirm(date ?? undefined)
-              }}}
+                onConfirm(date ?? nowDate);
+              }
+            }}
           >
             완료
           </button>


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 간단하게 설명해주세요

사진에 날짜가 없는 경우 사진 날짜 수정 모달에서 현재 날짜가 적용안되는 문제와 업로드한 대표 사진과 로컬의 있는 대표 사진을 비교하는 로직을 수정했습니다.
다만, 장기적으로 보았을 때 대표사진의 문제는 서버와 브라우저의 사진 고유값을 맞추는 방향으로 해결하면 좋을 것 같습니다.

